### PR TITLE
`ThreadSleepInAsyncMethod` does not suggest a no-op refactor if the method is not marked as `async`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.3.1] - 2022-09-03
+- `ThreadSleepInAsyncMethod` does not suggest a no-op refactor if the method is not marked as `async`
+
 ## [1.3.0] - 2022-09-02
 - `ElementaryMethodsOfTypeInCollectionNotOverridden` is more targeted and only warns if it finds an actual lookup that will be problematic
 - `ExceptionThrownFromProhibitedContext` doesn't crash when encountering empty `throw` statements

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ThreadSleepInAsyncMethodCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ThreadSleepInAsyncMethodCodeFix.cs
@@ -28,21 +28,21 @@ public class ThreadSleepInAsyncMethodCodeFix : CodeFixProvider
         var diagnosticSpan = diagnostic.Location.SourceSpan;
         var memberAccess = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
 
+        var isAsync = bool.Parse(diagnostic.Properties["isAsync"]);
+        if (!isAsync)
+        {
+            return;
+        }
+
         context.RegisterCodeFix(
             CodeAction.Create("Use Task.Delay",
-                x => UseTaskDelay(context.Document, memberAccess, root, diagnostic, x),
+                x => UseTaskDelay(context.Document, memberAccess, root),
                 ThreadSleepInAsyncMethodAnalyzer.Rule.Id),
             diagnostic);
     }
 
-    private Task<Document> UseTaskDelay(Document document, InvocationExpressionSyntax invocation, SyntaxNode root, Diagnostic diagnostic, CancellationToken cancellationToken)
+    private Task<Document> UseTaskDelay(Document document, InvocationExpressionSyntax invocation, SyntaxNode root)
     {
-        var isAsync = bool.Parse(diagnostic.Properties["isAsync"]);
-        if (!isAsync)
-        {
-            return Task.FromResult(document);
-        }
-
         ExpressionSyntax newExpression;
         if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
         {

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.3.0</PackageVersion>
+    <PackageVersion>1.3.1</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>


### PR DESCRIPTION
closes #123 