### PR TITLE
`FlagsEnumValuesAreNotPowersOfTwo` has been rewritten to reduce the scope of its warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.7.0] - 2022-09-05
+- `FlagsEnumValuesAreNotPowersOfTwo` has been rewritten to reduce the scope of its warning. Now it will only warn if a non-negative decimal literal is found which is not a power of two. A code fix will be available if a binary OR expression can be constructed with other enum members
+- `FlagsEnumValuesDontFit` will no longer fire as this was inaccurate and already covered by the default CA analyzers
+- `FlagsEnumValuesAreNotPowersOfTwo` will now mention the enum member that triggered the violation
+
 ## [1.6.0] - 2022-09-04
 - `AttributeMustSpecifyAttributeUsage`: warn when an attribute is defined without specifying the `[AttributeUsage]`
 - All internal code now uses nullable reference types

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Interested in contributing? Take a look at [the guidelines](./CONTRIBUTING.md)!
 | SS004  | ElementaryMethodsOfTypeInCollectionNotOverridden  | Implement `Equals()` and `GetHashcode()` methods for a type used in a collection. Collections use these to fetch objects but by default they use reference equality. Depending on where your objects come from, they might be missed in the lookup.  | Warning  | No  |
 | SS005  | EqualsAndGetHashcodeNotImplementedTogether  | Implement `Equals()` and `GetHashcode()` together. Implement both to ensure consistent behaviour around lookups.  | Warning  | Yes  |
 | SS006  | ThrowNull  | Throwing `null` will always result in a runtime exception.  | Error  | No  |
-| SS007  | FlagsEnumValuesAreNotPowersOfTwo  | A `[Flags]` enum its values are not explicit powers of 2.  | Error  | Yes  |
+| SS007  | FlagsEnumValuesAreNotPowersOfTwo  | `[Flags]` enum members need to be either powers of two, or bitwise OR expressions. This will fire if they are non-negative decimal literals that are not powers of two, and provide a code fix if the value can be achieved through a binary OR using other enum members. | Error  | Yes  |
 | SS008  | GetHashCodeRefersToMutableMember  | `GetHashCode(`) refers to mutable or static member. If the object is used in a collection and then is mutated, subsequent lookups will result in a different hash and might cause lookups to fail.   | Warning  | No  |
 | SS009  | LoopedRandomInstantiation  | An instance of type `System.Random` is created in a loop. `Random` uses a time-based seed so when used in a fast loop it will end up with multiple identical seeds for subsequent invocations.  | Warning  | No  |
 | SS010  | NewGuid  | An empty GUID was created in an ambiguous manner. The default `Guid` constructor creates an instance with an empty value which is rarely what you want.  | Error  | Yes   |
@@ -40,7 +40,6 @@ Interested in contributing? Take a look at [the guidelines](./CONTRIBUTING.md)!
 | SS028  | ExceptionThrownFromFinalizer  | An exception is thrown from a finalizer method  |  Warning  | No  |
 | SS029  | ExceptionThrownFromGetHashCode | An exception is thrown from a `GetHashCode()` method  |  Warning  | No  |
 | SS030  | ExceptionThrownFromEquals  | An exception is thrown from an `Equals() method`  |  Warning  | No  |
-| SS031  | FlagsEnumValuesDontFit  | A `[Flags]` enum its values are not explicit powers of 2 and its values dont fit in the specified enum type.  | Error  | No  |
 | SS032  | ThreadSleepInAsyncMethod  | Synchronously sleeping a thread in an `async` method combines two threading models and can lead to deadlocks.  | Warning  | Yes  |
 | SS033  | AsyncOverloadsAvailable  | An `async` overload is available. These overloads typically exist to provide better performing IO calls and should generally be preferred.  | Warning  | Yes  |
 | SS034  | AccessingTaskResultWithoutAwait  | Use `await` to get the result of an asynchronous operation. While accessing `.Result` is fine once the `Task` has been completed, this removes any ambiguity and helps prevent regressions if the code changes later on.  | Warning  | Yes  |

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/FlagsEnumValuesAreNotPowersOfTwoCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/FlagsEnumValuesAreNotPowersOfTwoCodeFix.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
-
 using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
@@ -17,111 +16,93 @@ namespace SharpSource.Diagnostics;
 [ExportCodeFixProvider(DiagnosticId.FlagsEnumValuesAreNotPowersOfTwo + "CF", LanguageNames.CSharp), Shared]
 public class FlagsEnumValuesAreNotPowersOfTwoCodeFix : CodeFixProvider
 {
-    public override ImmutableArray<string> FixableDiagnosticIds
-        => ImmutableArray.Create(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.Id);
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.Rule.Id);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
         var diagnostic = context.Diagnostics.First();
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-
-        var statement = root?.FindNode(diagnosticSpan);
-
-        if (root == default || statement == default)
+        var enumMember = root?.FindNode(diagnosticSpan)?.FirstAncestorOfType(SyntaxKind.EnumMemberDeclaration) as EnumMemberDeclarationSyntax;
+        var semanticModel = await context.Document.GetSemanticModelAsync();
+        if (root == default || enumMember == default || semanticModel == default)
         {
             return;
         }
 
-        context.RegisterCodeFix(
-            CodeAction.Create("Use powers of 2",
-                x => AdjustEnumValuesAsync(context.Document, root, statement),
-                FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.Id), diagnostic);
-    }
-
-    private async Task<Solution> AdjustEnumValuesAsync(Document document, SyntaxNode root, SyntaxNode statement)
-    {
-        var semanticModel = await document.GetSemanticModelAsync();
-
-        var declarationExpression = (EnumDeclarationSyntax)statement;
-
-        var declaredSymbol = semanticModel.GetDeclaredSymbol(declarationExpression);
-        var typeName = declaredSymbol?.EnumUnderlyingType?.MetadataName;
-
-        var enumMemberDeclarations =
-            declarationExpression.ChildNodes().OfType<EnumMemberDeclarationSyntax>().ToList();
-        var replacedValues = 0;
-
-        for (var i = 0; i < enumMemberDeclarations.Count; i++)
+        var targetConstant = semanticModel.GetDeclaredSymbol(enumMember)?.ConstantValue;
+        if (targetConstant == default)
         {
-            if (enumMemberDeclarations[i].EqualsValue != null)
+            return;
+        }
+
+        var enumDeclaration = enumMember.FirstAncestorOfType(SyntaxKind.EnumDeclaration);
+        if (enumDeclaration == default)
+        {
+            return;
+        }
+
+        var otherEnumMembers = enumDeclaration
+            .DescendantNodes()
+            .OfType<EnumMemberDeclarationSyntax>()
+            .Where(em => em.EqualsValue is { Value: LiteralExpressionSyntax })
+            .Except(new[] { enumMember })
+            .ToList();
+
+        // Make sure we don't recommend the same combination twice
+        // We do want to show the reverse, i.e. both A|B and B|A
+        HashSet<(object?, object?)> suggestedOptions = new();
+        foreach (var otherEnumMember in otherEnumMembers)
+        {
+            foreach (var otherEnumMemberAgain in otherEnumMembers)
             {
-                var descendantNodes = enumMemberDeclarations[i]?.EqualsValue?.Value.DescendantNodesAndSelf().ToList();
-                if (descendantNodes.Any() &&
-                    descendantNodes.All(n => n is IdentifierNameSyntax || n is BinaryExpressionSyntax))
+                // We won't use the same member in both operands
+                if (otherEnumMember.Equals(otherEnumMemberAgain))
                 {
                     continue;
                 }
+
+                var firstEnumMemberConstantValue = semanticModel.GetDeclaredSymbol(otherEnumMember)?.ConstantValue;
+                var secondEnumMemberConstantValue = semanticModel.GetDeclaredSymbol(otherEnumMemberAgain)?.ConstantValue;
+                if (IsCompatible(targetConstant, firstEnumMemberConstantValue, secondEnumMemberConstantValue) &&
+                    suggestedOptions.Add((firstEnumMemberConstantValue, secondEnumMemberConstantValue)))
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create("Use OR expression",
+                            x => UseBitwiseExpression(
+                                context.Document,
+                                root,
+                                enumMember,
+                                otherEnumMember.Identifier,
+                                otherEnumMemberAgain.Identifier),
+                            FlagsEnumValuesAreNotPowersOfTwoAnalyzer.Rule.Id), diagnostic);
+                }
             }
-
-            SyntaxToken literalToken;
-
-            // make sure we create a literal of the same type as the enum base type
-            // otherwise we can have issues with the type output
-            // ulong appends "UL" to the integer, while short doesn't, for example
-            switch (typeName)
-            {
-                case nameof(Int16):
-                    var newShort = replacedValues == 0 ? (short)0 : (short)Math.Pow(2, replacedValues - 1);
-                    literalToken = SyntaxFactory.Literal(newShort);
-                    break;
-                case nameof(UInt16):
-                    var newUshort = replacedValues == 0 ? (ushort)0 : (ushort)Math.Pow(2, replacedValues - 1);
-                    literalToken = SyntaxFactory.Literal(newUshort);
-                    break;
-                case nameof(Int32):
-                    var newInt = replacedValues == 0 ? 0 : (int)Math.Pow(2, replacedValues - 1);
-                    literalToken = SyntaxFactory.Literal(newInt);
-                    break;
-                case nameof(UInt32):
-                    var newUint = replacedValues == 0 ? 0 : (uint)Math.Pow(2, replacedValues - 1);
-                    literalToken = SyntaxFactory.Literal(newUint);
-                    break;
-                case nameof(Int64):
-                    var newLong = replacedValues == 0 ? 0 : (long)Math.Pow(2, replacedValues - 1);
-                    literalToken = SyntaxFactory.Literal(newLong);
-                    break;
-                case nameof(UInt64):
-                    var newUlong = replacedValues == 0 ? 0 : (ulong)Math.Pow(2, replacedValues - 1);
-                    literalToken = SyntaxFactory.Literal(newUlong);
-                    break;
-                case nameof(Byte):
-                    var newByte = replacedValues == 0 ? 0 : (byte)Math.Pow(2, replacedValues - 1);
-                    literalToken = SyntaxFactory.Literal(newByte);
-                    break;
-                case nameof(SByte):
-                    var newSByte = replacedValues == 0 ? 0 : (sbyte)Math.Pow(2, replacedValues - 1);
-                    literalToken = SyntaxFactory.Literal(newSByte);
-                    break;
-                default:
-                    throw new ArgumentException("Could not recognize [Flags] enum type.");
-            }
-            replacedValues++;
-
-            var literalExpression = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                literalToken);
-
-            var newEqualsValue = SyntaxFactory.EqualsValueClause(literalExpression);
-            enumMemberDeclarations[i] = enumMemberDeclarations[i].WithEqualsValue(newEqualsValue);
         }
-
-        var newStatement =
-            declarationExpression.WithMembers(SyntaxFactory.SeparatedList(enumMemberDeclarations))
-                                 .WithAdditionalAnnotations(Formatter.Annotation);
-
-        var newRoot = root.ReplaceNode(statement, newStatement);
-        return document.WithSyntaxRoot(newRoot).Project.Solution;
     }
+
+    private Task<Document> UseBitwiseExpression(Document document, SyntaxNode root, EnumMemberDeclarationSyntax enumMember, SyntaxToken firstIdentifier, SyntaxToken secondIdentifier)
+    {
+        var newValue = SyntaxFactory.BinaryExpression(SyntaxKind.BitwiseOrExpression, SyntaxFactory.IdentifierName(firstIdentifier), SyntaxFactory.IdentifierName(secondIdentifier));
+        var newMember = enumMember.WithEqualsValue(SyntaxFactory.EqualsValueClause(newValue)).WithAdditionalAnnotations(Formatter.Annotation);
+        var newRoot = root.ReplaceNode(enumMember, newMember);
+        var newDocument = document.WithSyntaxRoot(newRoot);
+        return Task.FromResult(newDocument);
+    }
+
+    private bool IsCompatible(object? target, object? first, object? second) =>
+        (target, first, second) switch
+        {
+            (int t, int f, int s) => ( f | s ) == t,
+            (uint t, uint f, uint s) => ( f | s ) == t,
+            (byte t, byte f, byte s) => ( f | s ) == t,
+            (sbyte t, sbyte f, sbyte s) => ( f | s ) == t,
+            (long t, long f, long s) => ( f | s ) == t,
+            (ulong t, ulong f, ulong s) => ( f | s ) == t,
+            (short t, short f, short s) => ( f | s ) == t,
+            (ushort t, ushort f, ushort s) => ( f | s ) == t,
+            _ => false
+        };
 }

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.6.0</PackageVersion>
+    <PackageVersion>1.7.0</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/FlagsEnumValuesAreNotPowersOfTwoTests.cs
+++ b/SharpSource/SharpSource.Test/FlagsEnumValuesAreNotPowersOfTwoTests.cs
@@ -19,36 +19,74 @@ public class FlagsEnumValuesAreNotPowersOfTwoTests : CSharpCodeFixVerifier
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = 4
-    }
+    Bar = 0,
+    Biz = 1,
+    Baz = 2,
+    Buz = 3,
+    Boz = 4
 }";
 
         var result = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
+    Bar = 0,
+    Biz = 1,
+    Baz = 2,
+    Buz = Biz | Baz,
+    Boz = 4
 }";
 
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
+        VerifyDiagnostic(original, "Enum Foo.Buz is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.");
+        VerifyFix(original, result);
+    }
+
+    [TestMethod]
+    [DataRow("int")]
+    [DataRow("uint")]
+    [DataRow("byte")]
+    [DataRow("sbyte")]
+    [DataRow("long")]
+    [DataRow("ulong")]
+    [DataRow("short")]
+    [DataRow("ushort")]
+    [DataRow("UInt16")]
+    [DataRow("UInt32")]
+    [DataRow("UInt64")]
+    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_DifferentTypes(string type)
+    {
+        var original = $@"
+using System;
+
+[Flags]
+enum Foo : {type}
+{{
+    Bar = 0,
+    Biz = 1,
+    Baz = 2,
+    Buz = 3,
+    Boz = 4
+}}";
+
+        var result = $@"
+using System;
+
+[Flags]
+enum Foo : {type}
+{{
+    Bar = 0,
+    Biz = 1,
+    Baz = 2,
+    Buz = Biz | Baz,
+    Boz = 4
+}}";
+
+        VerifyDiagnostic(original, "Enum Foo.Buz is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.");
         VerifyFix(original, result);
     }
 
@@ -58,17 +96,14 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
+    Bar = 0,
+    Biz = 1,
+    Baz = 2,
+    Buz = 4,
+    Boz = 8
 }";
 
         VerifyDiagnostic(original);
@@ -80,36 +115,30 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0x0,
-        Biz = 0x1,
-        Baz = 0x2,
-        Buz = 0x3,
-        Boz = 0x4
-    }
+    Bar = 0x0,
+    Biz = 0x1,
+    Baz = 0x2,
+    Buz = 0x3,
+    Boz = 0x4
 }";
 
         var result = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
+    Bar = 0x0,
+    Biz = 0x1,
+    Baz = 0x2,
+    Buz = Biz | Baz,
+    Boz = 0x4
 }";
 
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
+        VerifyDiagnostic(original, "Enum Foo.Buz is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.");
         VerifyFix(original, result);
     }
 
@@ -119,59 +148,34 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0x0,
-        Biz = 0x1,
-        Baz = 0x2,
-        Buz = 0x4,
-        Boz = 0x8
-    }
+    Bar = 0x0,
+    Biz = 0x1,
+    Baz = 0x2,
+    Buz = 0x4,
+    Boz = 0x8
 }";
 
         VerifyDiagnostic(original);
     }
 
     [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_NegativeValues()
+    public void FlagsEnumValuesAreNotPowersOfTwo_NegativeValues()
     {
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = -1,
-        Baz = -2,
-        Buz = -4,
-        Boz = -8
-    }
+    Biz = -1,
+    Baz = -2,
+    Buz = -3
 }";
 
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
+        VerifyDiagnostic(original);
     }
 
     [TestMethod]
@@ -180,400 +184,14 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0x0,
-        Biz,
-        Baz,
-        Buz,
-        Boz
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeShort()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : short
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = short.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : short
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_BaseTypeShort()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : short
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeUshort()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : ushort
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = ushort.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : ushort
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_BaseTypeUshort()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : ushort
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeInt()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : int
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = int.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : int
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_BaseTypeInt()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : int
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeUint()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : uint
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = uint.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : uint
-    {
-        Bar = 0U,
-        Biz = 1U,
-        Baz = 2U,
-        Buz = 4U,
-        Boz = 8U
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_BaseTypeUint()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : uint
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeLong()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : long
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = long.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : long
-    {
-        Bar = 0L,
-        Biz = 1L,
-        Baz = 2L,
-        Buz = 4L,
-        Boz = 8L
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_BaseTypeLong()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : long
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeUlong()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : ulong
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = ulong.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : ulong
-    {
-        Bar = 0UL,
-        Biz = 1UL,
-        Baz = 2UL,
-        Buz = 4UL,
-        Boz = 8UL
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_BaseTypeUlong()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : ulong
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
+    Bar,
+    Biz,
+    Baz,
+    Buz,
+    Boz
 }";
 
         VerifyDiagnostic(original);
@@ -583,16 +201,13 @@ namespace ConsoleApplication1
     public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_NotFlagsEnum()
     {
         var original = @"
-namespace ConsoleApplication1
+enum Foo
 {
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = 4
-    }
+    Bar = 0,
+    Biz = 1,
+    Baz = 2,
+    Buz = 3,
+    Boz = 4
 }";
 
         VerifyDiagnostic(original);
@@ -602,272 +217,28 @@ namespace ConsoleApplication1
     public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_FlagsEnum_WithSystemNamespace()
     {
         var original = @"
-using System;
-
-namespace ConsoleApplication1
+[System.Flags]
+enum Foo
 {
-    [System.Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = 4
-    }
+    Bar = 0,
+    Biz = 1,
+    Baz = 2,
+    Buz = 3,
+    Boz = 4
 }";
 
         var result = @"
-using System;
-
-namespace ConsoleApplication1
+[System.Flags]
+enum Foo
 {
-    [System.Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
+    Bar = 0,
+    Biz = 1,
+    Baz = 2,
+    Buz = Biz | Baz,
+    Boz = 4
 }";
 
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeInt16()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : Int16
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = short.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : Int16
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeUInt16()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : UInt16
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = ushort.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : UInt16
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeInt32()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : Int32
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = int.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : Int32
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeUInt32()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : UInt32
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = uint.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : UInt32
-    {
-        Bar = 0U,
-        Biz = 1U,
-        Baz = 2U,
-        Buz = 4U,
-        Boz = 8U
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeInt64()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : Int64
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = long.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : Int64
-    {
-        Bar = 0L,
-        Biz = 1L,
-        Baz = 2L,
-        Buz = 4L,
-        Boz = 8L
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeUInt64()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : UInt64
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = ulong.MaxValue
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : UInt64
-    {
-        Bar = 0UL,
-        Biz = 1UL,
-        Baz = 2UL,
-        Buz = 4UL,
-        Boz = 8UL
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
+        VerifyDiagnostic(original, "Enum Foo.Buz is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.");
         VerifyFix(original, result);
     }
 
@@ -877,17 +248,14 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1 << 0,
-        Baz = 1 << 1,
-        Buz = 1 << 2,
-        Boz = 1 << 3
-    }
+    Bar = 0,
+    Biz = 1 << 0,
+    Baz = 1 << 1,
+    Buz = 1 << 2,
+    Boz = 1 << 3
 }";
 
         VerifyDiagnostic(original);
@@ -899,117 +267,93 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Days
 {
-    [Flags]
-    enum Days
-    {
-        None = 0,
-        Sunday = 1,
-        Monday = 1 << 1,
-        WorkweekStart = Monday,
-        Tuesday = 1 << 2,
-        Wednesday = 1 << 3,
-        Thursday = 1 << 4,
-        Friday = 1 << 5,
-        WorkweekEnd = Friday,
-        Saturday = 1 << 6,
-        Weekend = Saturday | Sunday,
-        Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
-    }
+    None = 0,
+    Sunday = 1,
+    Monday = 1 << 1,
+    WorkweekStart = Monday,
+    Tuesday = 1 << 2,
+    Wednesday = 1 << 3,
+    Thursday = 1 << 4,
+    Friday = 1 << 5,
+    WorkweekEnd = Friday,
+    Saturday = 1 << 6,
+    Weekend = Saturday | Sunday,
+    Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
 }";
         VerifyDiagnostic(original);
     }
 
     [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_CharactersInsteadOfIntValues()
+    public void FlagsEnumValuesAreNotPowersOfTwo_CharValues()
     {
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        Bar = 'a',
-        Biz = 'b',
-        Baz = 'c',
-        Buz = 'd',
-        Boz = 'e'
-    }
+    Bar = 'a',
+    Biz = 'b',
+    Baz = 'c',
+    Buz = 'd',
+    Boz = 'e'
 }";
 
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
+        VerifyDiagnostic(original);
     }
 
     [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BinaryExpressionsWithAllIdentifiersAreLeft()
+    [Ignore("We need to support binary expressions on top of literals")]
+    public void FlagsEnumValuesAreNotPowersOfTwo_BinaryExpressions()
     {
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Days
 {
-    [Flags]
-    enum Days
-    {
-        None = 0,
-        Sunday = 1,
-        Monday = 2,
-        WorkweekStart = Monday,
-        Tuesday = 3,
-        Wednesday = 4,
-        Thursday = 5,
-        Friday = 6,
-        WorkweekEnd = Friday,
-        Saturday = 7,
-        Weekend = Saturday | Sunday,
-        Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
-    }
+    None = 0,
+    Sunday = 1,
+    Monday = 2,
+    WorkweekStart = Monday,
+    Tuesday = 3,
+    Wednesday = 4,
+    Thursday = 5,
+    Friday = 6,
+    WorkweekEnd = Friday,
+    Saturday = 7,
+    Weekend = Saturday | Sunday,
+    Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
 }";
 
         var result = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Days
 {
-    [Flags]
-    enum Days
-    {
-        None = 0,
-        Sunday = 1,
-        Monday = 2,
-        WorkweekStart = Monday,
-        Tuesday = 4,
-        Wednesday = 8,
-        Thursday = 16,
-        Friday = 32,
-        WorkweekEnd = Friday,
-        Saturday = 64,
-        Weekend = Saturday | Sunday,
-        Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
-    }
+    None = 0,
+    Sunday = 1,
+    Monday = 2,
+    WorkweekStart = Monday,
+    Tuesday = Sunday | Monday,
+    Wednesday = 4,
+    Thursday = Sunday | Wednesday,
+    Friday = Monday | Wednesday,
+    WorkweekEnd = Friday,
+    Saturday = Sunday | Friday,
+    Weekend = Saturday | Sunday,
+    Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
 }";
 
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Days"));
+        VerifyDiagnostic(original,
+            "Enum Days.Tuesday is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.",
+            "Enum Days.Thursday is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.",
+            "Enum Days.Friday is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.",
+            "Enum Days.Saturday is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.");
         VerifyFix(original, result);
     }
 
@@ -1019,51 +363,24 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Days
 {
-    [Flags]
-    enum Days
-    {
-        None = 0,
-        Sunday = 1,
-        Monday = 75 << 1,
-        WorkweekStart = Monday,
-        Tuesday = 75 << 2,
-        Wednesday = 75 << 3,
-        Thursday = 75 << 4,
-        Friday = 75 << 5,
-        WorkweekEnd = Friday,
-        Saturday = 75 << 6,
-        Weekend = Saturday | Sunday,
-        Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
-    }
+    None = 0,
+    Sunday = 1,
+    Monday = 75 << 1,
+    WorkweekStart = Monday,
+    Tuesday = 75 << 2,
+    Wednesday = 75 << 3,
+    Thursday = 75 << 4,
+    Friday = 75 << 5,
+    WorkweekEnd = Friday,
+    Saturday = 75 << 6,
+    Weekend = Saturday | Sunday,
+    Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
 }";
 
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Days
-    {
-        None = 0,
-        Sunday = 1,
-        Monday = 2,
-        WorkweekStart = Monday,
-        Tuesday = 4,
-        Wednesday = 8,
-        Thursday = 16,
-        Friday = 32,
-        WorkweekEnd = Friday,
-        Saturday = 64,
-        Weekend = Saturday | Sunday,
-        Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Days"));
-        VerifyFix(original, result);
+        VerifyDiagnostic(original);
     }
 
     [TestMethod]
@@ -1072,58 +389,24 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Days
 {
-    [Flags]
-    enum Days
-    {
-        None = 0,
-        Sunday = 1,
-        Monday = 1 << 1,
-        WorkweekStart = Monday,
-        Tuesday = 1 << 2,
-        Wednesday = 1 << 3,
-        Thursday = 1 << 4,
-        Friday = 1 << 5,
-        WorkweekEnd = Friday | 63,
-        Saturday = 1 << 6,
-        Weekend = Saturday | Sunday,
-        Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
-    }
+    None = 0,
+    Sunday = 1,
+    Monday = 1 << 1,
+    WorkweekStart = Monday,
+    Tuesday = 1 << 2,
+    Wednesday = 1 << 3,
+    Thursday = 1 << 4,
+    Friday = 1 << 5,
+    WorkweekEnd = Friday | 63,
+    Saturday = 1 << 6,
+    Weekend = Saturday | Sunday,
+    Weekdays = Monday | Tuesday | Wednesday | Thursday | Friday
 }";
 
         VerifyDiagnostic(original);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_EnsuresFixLooksNice()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    public enum CalendarType { Camp, Activity }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    public enum CalendarType
-    {
-        Camp = 0,
-        Activity = 1
-    }
-}";
-
-        VerifyDiagnostic(original,
-            string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "CalendarType"));
-        VerifyFix(original, result);
-
     }
 
     [TestMethod]
@@ -1132,498 +415,47 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-namespace ConsoleApplication1
+[Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        A,
-        B,
-        C
+    A,
+    B,
+    C
+}";
+
+        VerifyDiagnostic(original);
     }
+
+    [TestMethod]
+    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesArePowersOfTwo_MultipleOptions()
+    {
+        var original = @"
+[System.Flags]
+enum Foo
+{
+    Bar = 0,
+    Biz = 1,
+    Bip = 2,
+    Baz = 2,
+    Buz = 4,
+    Boz = 8,
+    Bop = 10,
 }";
 
         var result = @"
-using System;
-
-namespace ConsoleApplication1
+[System.Flags]
+enum Foo
 {
-    [Flags]
-    enum Foo
-    {
-        A = 0,
-        B = 1,
-        C = 2
-    }
+    Bar = 0,
+    Biz = 1,
+    Bip = 2,
+    Baz = 2,
+    Buz = 4,
+    Boz = 8,
+    Bop = Bip | Boz,
 }";
 
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
+        VerifyDiagnostic(original, "Enum Foo.Bop is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.");
         VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeByte()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : byte
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = 4
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : byte
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ValuesAreNotPowersOfTwo_BaseTypeSByte()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : sbyte
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 3,
-        Boz = 4
-    }
-}";
-
-        var result = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : sbyte
-    {
-        Bar = 0,
-        Biz = 1,
-        Baz = 2,
-        Buz = 4,
-        Boz = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.DefaultRule.MessageFormat.ToString(), "Foo"));
-        VerifyFix(original, result);
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_Byte_TooManyMembersForFlags()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : byte
-    {
-        A = 0,
-        B = 1,
-        C = 2,
-        D = 3,
-        E = 4,
-        F = 5,
-        G = 6,
-        H = 7,
-        I = 8,
-        J = 9
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.ValuesDontFitRule.MessageFormat.ToString(), "Foo", "byte"));
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_SByte_TooManyMembersForFlags()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : sbyte
-    {
-        A = 0,
-        B = 1,
-        C = 2,
-        D = 3,
-        E = 4,
-        F = 5,
-        G = 6,
-        H = 7,
-        I = 8
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.ValuesDontFitRule.MessageFormat.ToString(), "Foo", "sbyte"));
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_int_TooManyMembersForFlags()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : int
-    {
-	    A = 0,
-	    B = 1,
-	    C = 2,
-	    D = 3,
-	    E = 4,
-	    F = 5,
-	    G = 6,
-	    H = 7,
-	    I = 8,
-	    J = 9,
-	    K = 10,
-	    L = 11,
-	    M = 12,
-	    N = 13,
-	    O = 14,
-	    P = 15,
-	    Q = 16,
-	    R = 17,
-	    S = 18,
-	    T = 19,
-	    U = 20,
-	    V = 21,
-	    W = 22,
-	    X = 23,
-	    Y = 24,
-	    Z = 25,
-	    AA = 26,
-	    BB = 27,
-	    CC = 28,
-	    DD = 29,
-	    EE = 30,
-	    FF = 31,
-        GG = 32
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.ValuesDontFitRule.MessageFormat.ToString(), "Foo", "int"));
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_uint_TooManyMembersForFlags()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : uint
-    {
-	    A = 0,
-	    B = 1,
-	    C = 2,
-	    D = 3,
-	    E = 4,
-	    F = 5,
-	    G = 6,
-	    H = 7,
-	    I = 8,
-	    J = 9,
-	    K = 10,
-	    L = 11,
-	    M = 12,
-	    N = 13,
-	    O = 14,
-	    P = 15,
-	    Q = 16,
-	    R = 17,
-	    S = 18,
-	    T = 19,
-	    U = 20,
-	    V = 21,
-	    W = 22,
-	    X = 23,
-	    Y = 24,
-	    Z = 25,
-	    AA = 26,
-	    BB = 27,
-	    CC = 28,
-	    DD = 29,
-	    EE = 30,
-	    FF = 31,
-        GG = 32,
-        HH = 33
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.ValuesDontFitRule.MessageFormat.ToString(), "Foo", "uint"));
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_short_TooManyMembersForFlags()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : short
-    {
-	    A = 0,
-	    B = 1,
-	    C = 2,
-	    D = 3,
-	    E = 4,
-	    F = 5,
-	    G = 6,
-	    H = 7,
-	    I = 8,
-	    J = 9,
-	    K = 10,
-	    L = 11,
-	    M = 12,
-	    N = 13,
-	    O = 14,
-	    P = 15,
-        Q = 16
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.ValuesDontFitRule.MessageFormat.ToString(), "Foo", "short"));
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ushort_TooManyMembersForFlags()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : ushort
-    {
-	    A = 0,
-	    B = 1,
-	    C = 2,
-	    D = 3,
-	    E = 4,
-	    F = 5,
-	    G = 6,
-	    H = 7,
-	    I = 8,
-	    J = 9,
-	    K = 10,
-	    L = 11,
-	    M = 12,
-	    N = 13,
-	    O = 14,
-	    P = 15,
-        Q = 16,
-        R = 17
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.ValuesDontFitRule.MessageFormat.ToString(), "Foo", "ushort"));
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_long_TooManyMembersForFlags()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : long
-    {
-	    A = 0L,
-	    B = 1L,
-	    C = 1L << 1,
-	    D = 1L << 2,
-	    E = 1L << 3,
-	    F = 1L << 4,
-	    G = 1L << 5,
-	    H = 1L << 6,
-	    I = 1L << 7,
-	    J = 1L << 8,
-	    K = 1L << 9,
-	    L = 1L << 10,
-	    M = 1L << 11,
-	    N = 1L << 12,
-	    O = 1L << 13,
-	    P = 1L << 14,
-	    Q = 1L << 15,
-	    R = 1L << 16,
-	    S = 1L << 17,
-	    T = 1L << 18,
-	    U = 1L << 19,
-	    V = 1L << 20,
-	    W = 1L << 21,
-	    X = 1L << 22,
-	    Y = 1L << 23,
-	    Z = 1L << 24,
-	    AA = 1L << 25,
-	    BB = 1L << 26,
-	    CC = 1L << 27,
-	    DD = 1L << 28,
-	    EE = 1L << 29,
-	    FF = 1L << 30,
-	    GG = 1L << 31,
-        HH = 1L << 32,
-	    II = 1L << 33,
-	    JJ = 1L << 34,
-	    KK = 1L << 35,
-	    LL = 1L << 36,
-	    MM = 1L << 37,
-	    NN = 1L << 38,
-	    OO = 1L << 39,
-	    PP = 1L << 40,
-	    QQ = 1L << 41,
-	    RR = 1L << 42,
-	    SS = 1L << 43,
-	    TT = 1L << 44,
-	    UU = 1L << 45,
-	    VV = 1L << 46,
-	    WW = 1L << 47,
-	    XX = 1L << 48,
-	    YY = 1L << 49,
-	    ZZ = 1L << 50,
-	    AAA = 1L << 51,
-	    BBB = 1L << 52,
-	    CCC = 1L << 53,
-	    DDD = 1L << 54,
-	    EEE = 1L << 55,
-	    FFF = 1L << 56,
-	    GGG = 1L << 57,
-	    HHH = 1L << 58,
-	    III = 1L << 59,
-	    JJJ = 1L << 60,
-	    KKK = 1L << 61,
-	    LLL = 1L << 62,
-        MMM = 1L << 63
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.ValuesDontFitRule.MessageFormat.ToString(), "Foo", "long"));
-    }
-
-    [TestMethod]
-    public void FlagsEnumValuesAreNotPowersOfTwo_ulong_TooManyMembersForFlags()
-    {
-        var original = @"
-using System;
-
-namespace ConsoleApplication1
-{
-    [Flags]
-    enum Foo : ulong
-    {
-		A = 0UL,
-		B = 1UL,
-		C = 1UL << 1,
-		D = 1UL << 2,
-		E = 1UL << 3,
-		F = 1UL << 4,
-		G = 1UL << 5,
-		H = 1UL << 6,
-		I = 1UL << 7,
-		J = 1UL << 8,
-		K = 1UL << 9,
-		L = 1UL << 10,
-		M = 1UL << 11,
-		N = 1UL << 12,
-		O = 1UL << 13,
-		P = 1UL << 14,
-		Q = 1UL << 15,
-		R = 1UL << 16,
-		S = 1UL << 17,
-		T = 1UL << 18,
-		U = 1UL << 19,
-		V = 1UL << 20,
-		W = 1UL << 21,
-		X = 1UL << 22,
-		Y = 1UL << 23,
-		Z = 1UL << 24,
-		AA = 1UL << 25,
-		BB = 1UL << 26,
-		CC = 1UL << 27,
-		DD = 1UL << 28,
-		EE = 1UL << 29,
-		FF = 1UL << 30,
-		GG = 1UL << 31,
-	    HH = 1UL << 32,
-		II = 1UL << 33,
-		JJ = 1UL << 34,
-		KK = 1UL << 35,
-		LL = 1UL << 36,
-		MM = 1UL << 37,
-		NN = 1UL << 38,
-		OO = 1UL << 39,
-		PP = 1UL << 40,
-		QQ = 1UL << 41,
-		RR = 1UL << 42,
-		SS = 1UL << 43,
-		TT = 1UL << 44,
-		UU = 1UL << 45,
-		VV = 1UL << 46,
-		WW = 1UL << 47,
-		XX = 1UL << 48,
-		YY = 1UL << 49,
-		ZZ = 1UL << 50,
-		AAA = 1UL << 51,
-		BBB = 1UL << 52,
-		CCC = 1UL << 53,
-		DDD = 1UL << 54,
-		EEE = 1UL << 55,
-		FFF = 1UL << 56,
-		GGG = 1UL << 57,
-		HHH = 1UL << 58,
-		III = 1UL << 59,
-		JJJ = 1UL << 60,
-		KKK = 1UL << 61,
-		LLL = 1UL << 62,
-		MMM = 1UL << 63,
-        NNN = 1UL << 64
-    }
-}";
-
-        VerifyDiagnostic(original, string.Format(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.ValuesDontFitRule.MessageFormat.ToString(), "Foo", "ulong"));
     }
 }

--- a/SharpSource/SharpSource/Utilities/DiagnosticId.cs
+++ b/SharpSource/SharpSource/Utilities/DiagnosticId.cs
@@ -30,7 +30,6 @@ public static class DiagnosticId
     public const string ExceptionThrownFromFinalizer = "SS028";
     public const string ExceptionThrownFromGetHashCode = "SS029";
     public const string ExceptionThrownFromEquals = "SS030";
-    public const string FlagsEnumValuesDontFit = "SS031";
     public const string ThreadSleepInAsyncMethod = "SS032";
     public const string AsyncOverloadsAvailable = "SS033";
     public const string AccessingTaskResultWithoutAwait = "SS034";


### PR DESCRIPTION
closes #92 
closes #89 