### PR TITLE
SwitchIsMissingDefaultLabel in top-level statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
-## [1.11.0] - 2022-09-19
+## [1.11.1] - 2022-09-25
+- `SwitchIsMissingDefaultLabel`: code fix now works in top-level statements
+
+## [1.11.0] - 2022-09-24
 - `ComparingStringsWithoutStringComparison`: A `string` is being compared through allocating a new `string`, e.g. using `ToLower()` or `ToUpperInvariant()`. Use a case-insensitive comparison instead which does not allocate.
 - `UnnecessaryEnumerableMaterialization`: supports `!.` operator
 - `ElementaryMethodsOfTypeInCollectionNotOverridden`: supports `?.` and `!.` operators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ https://keepachangelog.com/en/1.0.0/
 
 ## [1.11.1] - 2022-09-25
 - `SwitchIsMissingDefaultLabel`: code fix now works in top-level statements
+- `AttributeMustSpecifyAttributeUsage`: correctly fires when the type is defined in the netstandard assembly
 
 ## [1.11.0] - 2022-09-24
 - `ComparingStringsWithoutStringComparison`: A `string` is being compared through allocating a new `string`, e.g. using `ToLower()` or `ToUpperInvariant()`. Use a case-insensitive comparison instead which does not allocate.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.11.0" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.11.1" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchIsMissingDefaultLabelCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchIsMissingDefaultLabelCodeFix.cs
@@ -25,11 +25,12 @@ public class SwitchIsMissingDefaultLabelCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
         var diagnostic = context.Diagnostics.First();
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-        var statement = root?.FindNode(diagnosticSpan).FirstAncestorOrSelf<SwitchStatementSyntax>(x => x is not null);
+        var switchToken = root?.FindNode(diagnosticSpan);
+        var statement = switchToken?.DescendantNodesAndSelf().FirstOfKind<SwitchStatementSyntax>(SyntaxKind.SwitchStatement);
         if (root is not CompilationUnitSyntax compilation || statement == default)
         {
             return;

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.11.0</PackageVersion>
+    <PackageVersion>1.11.1</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/SwitchIsMissingDefaultLabelTests.cs
+++ b/SharpSource/SharpSource.Test/SwitchIsMissingDefaultLabelTests.cs
@@ -339,7 +339,7 @@ namespace ConsoleApplication1
     }
 
     [TestMethod]
-    public async Task SwitchIsMissingDefaultLabel_MissingDefaultStatement_SwitchOnParenthsizedIntegerLiteral()
+    public async Task SwitchIsMissingDefaultLabel_MissingDefaultStatement_SwitchOnParenthesizedIntegerLiteral()
     {
         var original = @"
 using System;
@@ -424,6 +424,35 @@ namespace ConsoleApplication1
         }
     }
 }";
+
+        await VerifyDiagnostic(original, "Switch should have default label.");
+        await VerifyFix(original, result);
+    }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/167")]
+    public async Task SwitchIsMissingDefaultLabel_TopLevelStatement()
+    {
+        var original = @"
+using System;
+
+switch (Test.A)
+{
+    case Test.A: return;
+}
+
+enum Test { A, B }";
+
+        var result = @"
+using System;
+
+switch (Test.A)
+{
+    case Test.A: return;
+    default:
+        throw new ArgumentException(""Unsupported value"");
+}
+
+enum Test { A, B }";
 
         await VerifyDiagnostic(original, "Switch should have default label.");
         await VerifyFix(original, result);

--- a/SharpSource/SharpSource/Utilities/Extensions.cs
+++ b/SharpSource/SharpSource/Utilities/Extensions.cs
@@ -377,7 +377,8 @@ public static class Extensions
     public static bool IsDefinedInSystemAssembly(this ISymbol symbol)
         => symbol.ContainingAssembly.Name == "mscorlib" ||
             symbol.ContainingAssembly.Name.StartsWith("System.") ||
-            symbol.ContainingAssembly.Name.StartsWith("Microsoft.");
+            symbol.ContainingAssembly.Name.StartsWith("Microsoft.") ||
+            symbol.ContainingAssembly.Name == "netstandard";
 
     public static IEnumerable<AttributeSyntax> GetAttributesOfType(this SyntaxList<AttributeListSyntax> attributes, Type type, SemanticModel semanticModel) =>
         attributes.SelectMany(x => x.Attributes).Where(a =>


### PR DESCRIPTION
closes #167 
closes #169 