### PR TITLE
Use Microsoft's testing library for AccessingtaskResultWithoutAwaitTests

### DIFF
--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/AsyncMethodWithVoidReturnTypeCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/AsyncMethodWithVoidReturnTypeCodeFix.cs
@@ -15,7 +15,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.AsyncMethodWithVoidReturnType + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class AsyncMethodWithVoidReturnTypeCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/AsyncOverloadsAvailableCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/AsyncOverloadsAvailableCodeFix.cs
@@ -12,7 +12,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.AsyncOverloadsAvailable + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class AsyncOverloadsAvailableCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(AsyncOverloadsAvailableAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/AttributeMustSpecifyAttributeUsageCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/AttributeMustSpecifyAttributeUsageCodeFix.cs
@@ -11,7 +11,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.AttributeMustSpecifyAttributeUsage + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class AttributeMustSpecifyAttributeUsageCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(AttributeMustSpecifyAttributeUsageAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ComparingStringsWithoutStringComparisonCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ComparingStringsWithoutStringComparisonCodeFix.cs
@@ -11,7 +11,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.ComparingStringsWithoutStringComparison + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class ComparingStringsWithoutStringComparisonCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticId.ComparingStringsWithoutStringComparison);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/DateTimeNowCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/DateTimeNowCodeFix.cs
@@ -12,7 +12,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.DateTimeNow + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class DateTimeNowCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DateTimeNowAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/EqualsAndGetHashcodeNotImplementedTogetherCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/EqualsAndGetHashcodeNotImplementedTogetherCodeFix.cs
@@ -13,7 +13,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.EqualsAndGetHashcodeNotImplementedTogether + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class EqualsAndGetHashcodeNotImplementedTogetherCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(EqualsAndGetHashcodeNotImplementedTogetherAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ExplicitEnumValuesCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ExplicitEnumValuesCodeFix.cs
@@ -13,7 +13,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.ExplicitEnumValues + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class ExplicitEnumValuesCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ExplicitEnumValuesAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/FlagsEnumValuesAreNotPowersOfTwoCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/FlagsEnumValuesAreNotPowersOfTwoCodeFix.cs
@@ -13,7 +13,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.FlagsEnumValuesAreNotPowersOfTwo + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class FlagsEnumValuesAreNotPowersOfTwoCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(FlagsEnumValuesAreNotPowersOfTwoAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/LockingOnMutableReferenceCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/LockingOnMutableReferenceCodeFix.cs
@@ -11,7 +11,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.LockingOnMutableReference + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class LockingOnMutableReferenceCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticId.LockingOnMutableReference);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/NewGuidCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/NewGuidCodeFix.cs
@@ -12,7 +12,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.NewGuid + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class NewGuidCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(NewGuidAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/OnPropertyChangedWithoutNameOfOperatorCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/OnPropertyChangedWithoutNameOfOperatorCodeFix.cs
@@ -11,7 +11,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.OnPropertyChangedWithoutNameofOperator + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class OnPropertyChangedWithoutNameOfOperatorCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -41,7 +41,7 @@ public class OnPropertyChangedWithoutNameOfOperatorCodeFix : CodeFixProvider
         var startLocation = int.Parse(diagnostic.Properties["startLocation"]);
 
         // We have to use LastOrDefault because encompassing nodes will have the same start location
-        // For example in our scenario of OnPropertyChanged("test"), the ArgumentSyntaxNode will have 
+        // For example in our scenario of OnPropertyChanged("test"), the ArgumentSyntaxNode will have
         // the same start location as the following LiteralExpressionNode
         // We are interested in the inner-most node therefore we need to take the last one with that start location
         var nodeToReplace = root.DescendantNodesAndSelf().LastOrDefault(x => x.SpanStart == startLocation);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ParameterAssignedInConstructorCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ParameterAssignedInConstructorCodeFix.cs
@@ -12,7 +12,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.ParameterAssignedInConstructor + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class ParameterAssignedInConstructorCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticId.ParameterAssignedInConstructor);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/RethrowExceptionWithoutLosingStacktraceCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/RethrowExceptionWithoutLosingStacktraceCodeFix.cs
@@ -12,7 +12,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.RethrowExceptionWithoutLosingStacktrace + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class RethrowExceptionWithoutLosingStacktraceCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/StringPlaceholdersInWrongOrderCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/StringPlaceholdersInWrongOrderCodeFix.cs
@@ -14,7 +14,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.StringPlaceholdersInWrongOrder + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class StringPlaceHoldersInWrongOrderCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -68,7 +68,7 @@ public class StringPlaceHoldersInWrongOrderCodeFix : CodeFixProvider
         // This contains the order in which the placeholders appeared in the original format string.
         // For example if it had the string "{1} x {0} y {2} {2}" then this collection would contain the values 1-0-2.
         // You'll notice that we omitted the duplicate: we don't want to add an argument twice.
-        // Typically we'd do this by using a HashSet<T> but since we can't easily retrieve an item from the HashSet<T>, 
+        // Typically we'd do this by using a HashSet<T> but since we can't easily retrieve an item from the HashSet<T>,
         // we'll just check for duplicates upon inserting in the list.
         // Based on this we can then reconstruct the argument list by reordering the existing arguments.
         var placeholderIndexOrder = new List<int>();

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/StructWithoutElementaryMethodsOverriddenCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/StructWithoutElementaryMethodsOverriddenCodeFix.cs
@@ -14,7 +14,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.StructWithoutElementaryMethodsOverridden + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class StructWithoutElementaryMethodsOverriddenCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchDoesNotHandleAllEnumOptionsCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchDoesNotHandleAllEnumOptionsCodeFix.cs
@@ -15,7 +15,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.SwitchDoesNotHandleAllEnumOptions + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class SwitchDoesNotHandleAllEnumOptionsCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchIsMissingDefaultLabelCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchIsMissingDefaultLabelCodeFix.cs
@@ -15,7 +15,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.SwitchIsMissingDefaultLabel + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class SwitchIsMissingDefaultLabelCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SynchronousTaskWaitCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SynchronousTaskWaitCodeFix.cs
@@ -12,7 +12,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.SynchronousTaskWait + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class SynchronousTaskWaitCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SynchronousTaskWaitAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/TestMethodWithoutPublicModifierCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/TestMethodWithoutPublicModifierCodeFix.cs
@@ -11,7 +11,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.TestMethodWithoutPublicModifier + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class TestMethodWithoutPublicModifierCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ThreadSleepInAsyncMethodCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ThreadSleepInAsyncMethodCodeFix.cs
@@ -14,7 +14,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.ThreadSleepInAsyncMethod + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class ThreadSleepInAsyncMethodCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ThreadSleepInAsyncMethodAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/UnboundedStackallocCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/UnboundedStackallocCodeFix.cs
@@ -11,7 +11,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.UnboundedStackalloc + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class UnboundedStackallocCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticId.UnboundedStackalloc);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/UnnecessaryEnumerableMaterializationCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/UnnecessaryEnumerableMaterializationCodeFix.cs
@@ -11,7 +11,7 @@ using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
-[ExportCodeFixProvider(DiagnosticId.UnnecessaryEnumerableMaterialization + "CF", LanguageNames.CSharp), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class UnnecessaryEnumerableMaterializationCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(UnnecessaryEnumerableMaterializationAnalyzer.Rule.Id);

--- a/SharpSource/SharpSource.Test/AccessingTaskResultWithoutAwaitTests.cs
+++ b/SharpSource/SharpSource.Test/AccessingTaskResultWithoutAwaitTests.cs
@@ -1,19 +1,15 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpSource.Diagnostics;
 using SharpSource.Test.Helpers;
+
+using VerifyCS = SharpSource.Test.CSharpCodeFixVerifier<SharpSource.Diagnostics.AccessingTaskResultWithoutAwaitAnalyzer, SharpSource.Diagnostics.AccessingTaskResultWithoutAwaitCodeFix>;
 
 namespace SharpSource.Test;
 
 [TestClass]
-public class AccessingTaskResultWithoutAwaitTests : DiagnosticVerifier
+public class AccessingTaskResultWithoutAwaitTests
 {
-    protected override DiagnosticAnalyzer DiagnosticAnalyzer => new AccessingTaskResultWithoutAwaitAnalyzer();
-
-    protected override CodeFixProvider CodeFixProvider => new AccessingTaskResultWithoutAwaitCodeFix();
-
     [TestMethod]
     public async Task AccessingTaskResultWithoutAwait_AsyncContext()
     {
@@ -28,7 +24,7 @@ namespace ConsoleApplication1
     {   
         async Task MyMethod()
         {
-            var number = Other().Result;
+            var number = {|#0:Other().Result|};
         }
 
         async Task<int> Other() => 5;
@@ -52,9 +48,7 @@ namespace ConsoleApplication1
         async Task<int> Other() => 5;
     }
 }";
-
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await VerifyCS.VerifyCodeFixAsync(original, VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."), result);
     }
 
     [TestMethod]
@@ -79,7 +73,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original);
+        await VerifyCS.VerifyCodeFixAsync(original, original);
     }
 
     [TestMethod]
@@ -96,7 +90,7 @@ namespace ConsoleApplication1
     {   
         async void MyMethod()
         {
-            var number = Other().Result;
+            var number = {|#0:Other().Result|};
         }
 
         async Task<int> Other() => 5;
@@ -121,8 +115,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await VerifyCS.VerifyCodeFixAsync(original, VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."), result);
     }
 
     [TestMethod]
@@ -137,7 +130,7 @@ namespace ConsoleApplication1
 {
     class MyClass
     {   
-        async Task<int> MyMethod() => Other().Result;
+        async Task<int> MyMethod() => {|#0:Other().Result|};
 
         async Task<int> Other() => 5;
     }
@@ -158,8 +151,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await VerifyCS.VerifyCodeFixAsync(original, VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."), result);
     }
 
     [TestMethod]
@@ -174,7 +166,7 @@ namespace ConsoleApplication1
 {
     class MyClass
     {   
-        async Task<int> MyMethod() => new MyClass().Other().Result;
+        async Task<int> MyMethod() => {|#0:new MyClass().Other().Result|};
 
         async Task<int> Other() => 5;
     }
@@ -195,8 +187,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await VerifyCS.VerifyCodeFixAsync(original, VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."), result);
     }
 
     [TestMethod]
@@ -211,7 +202,7 @@ namespace ConsoleApplication1
 {
     class MyClass
     {
-	    Action MyMethod() => new Action(async () => Console.Write(Other().Result));
+	    Action MyMethod() => new Action(async () => Console.Write({|#0:Other().Result|}));
 
 	    async Task<int> Other() => 5;
     }
@@ -232,8 +223,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await VerifyCS.VerifyCodeFixAsync(original, VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."), result);
     }
 
     [TestMethod]
@@ -254,7 +244,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original);
+        await VerifyCS.VerifyCodeFixAsync(original, original);
     }
 
     [TestMethod]
@@ -278,7 +268,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original);
+        await VerifyCS.VerifyCodeFixAsync(original, original);
     }
 
     [TestMethod]
@@ -297,7 +287,7 @@ namespace ConsoleApplication1
 
         async Task MyMethod()
         {
-            var number = Other().Result.SomeField;
+            var number = {|#0:Other().Result|}.SomeField;
         }
 
         async Task<MyClass> Other() => this;
@@ -324,8 +314,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await VerifyCS.VerifyCodeFixAsync(original, VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."), result);
     }
 
     [TestMethod]
@@ -343,7 +332,7 @@ namespace ConsoleApplication1
 	    async Task MyMethod()
 	    {
 		    Console.Write(new {
-			    Prop = Get().Result
+			    Prop = {|#0:Get().Result|}
 		    });
 	    }
 	
@@ -371,8 +360,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await VerifyCS.VerifyCodeFixAsync(original, VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."), result);
     }
 
     [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/111")]
@@ -388,7 +376,7 @@ namespace ConsoleApplication1
     {   
         async Task MyMethod()
         {
-            var number = Other().Result;
+            var number = {|#0:Other().Result|};
         }
 
         async ValueTask<int> Other() => 5;
@@ -412,8 +400,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await VerifyCS.VerifyCodeFixAsync(original, VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."), result);
     }
 
     [TestMethod]
@@ -429,7 +416,7 @@ await DoThing(File.Open("""", FileMode.Open));
 
 async Task DoThing(FileStream file) 
 {
-    var result = file.ReadAsync(new byte[] {}, 0, 0, CancellationToken.None).Result;
+    var result = {|#0:file.ReadAsync(new byte[] {}, 0, 0, CancellationToken.None).Result|};
 }";
 
         var result = @"
@@ -444,15 +431,27 @@ async Task DoThing(FileStream file)
 {
     var result = await file.ReadAsync(new byte[] {}, 0, 0, CancellationToken.None);
 }";
-
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await new VerifyCS.Test
+        {
+            TestState =
+            {
+                Sources = { original },
+                OutputKind = OutputKind.ConsoleApplication,
+            },
+            FixedCode = result,
+            ExpectedDiagnostics =
+            {
+                VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."),
+            },
+        }.RunAsync();
     }
 
     [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/146")]
     public async Task AccessingTaskResultWithoutAwait_NullableAccess_DoesNotSuggestFix()
     {
         var original = @"
+#nullable enable
+
 using System;
 using System.IO;
 using System.Threading;
@@ -462,23 +461,21 @@ await DoThing(File.Open("""", FileMode.Open));
 
 async Task DoThing(FileStream? file) 
 {
-    var result = file?.ReadAsync(new byte[] {}, 0, 0, CancellationToken.None).Result;
+    var result = file?{|#0:.ReadAsync(new byte[] {}, 0, 0, CancellationToken.None).Result|};
 }";
 
-        var result = @"
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-
-await DoThing(File.Open("""", FileMode.Open));
-
-async Task DoThing(FileStream? file) 
-{
-    var result = file?.ReadAsync(new byte[] {}, 0, 0, CancellationToken.None).Result;
-}";
-
-        await VerifyDiagnostic(original, "Use await to get the result of a Task.");
-        await VerifyFix(original, result);
+        await new VerifyCS.Test
+        {
+            TestState =
+            {
+                Sources = { original },
+                OutputKind = OutputKind.ConsoleApplication,
+            },
+            FixedCode = original,
+            ExpectedDiagnostics =
+            {
+                VerifyCS.Diagnostic().WithLocation(0).WithMessage("Use await to get the result of a Task."),
+            },
+        }.RunAsync();
     }
 }

--- a/SharpSource/SharpSource.Test/SharpSource.Test.csproj
+++ b/SharpSource/SharpSource.Test/SharpSource.Test.csproj
@@ -11,12 +11,12 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.1.1" />
   </ItemGroup>
 
   <!-- For unit testing purposes -->

--- a/SharpSource/SharpSource.Test/Verifiers/CSCodeFix+Test.cs
+++ b/SharpSource/SharpSource.Test/Verifiers/CSCodeFix+Test.cs
@@ -1,0 +1,33 @@
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace SharpSource.Test
+{
+    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, MSTestVerifier>
+        {
+            public Test()
+            {
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var compilationOptions = solution.GetProject(projectId)!.CompilationOptions!;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    return solution;
+                });
+
+                TestState.AnalyzerConfigFiles.Add(("/.globalconfig", @"
+is_global = true
+end_of_line = lf
+"));
+            }
+        }
+    }
+}

--- a/SharpSource/SharpSource.Test/Verifiers/CSCodeFix.cs
+++ b/SharpSource/SharpSource.Test/Verifiers/CSCodeFix.cs
@@ -1,0 +1,61 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace SharpSource.Test
+{
+    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/SharpSource/SharpSource.Test/Verifiers/CSHelper.cs
+++ b/SharpSource/SharpSource.Test/Verifiers/CSHelper.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace SharpSource.Test
+{
+    internal static class CSharpVerifierHelper
+    {
+        /// <summary>
+        /// By default, the compiler reports diagnostics for nullable reference types at
+        /// <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating
+        /// diagnostics at <see cref="DiagnosticSeverity.Error"/>. This map contains all compiler diagnostic IDs
+        /// related to nullability mapped to <see cref="ReportDiagnostic.Error"/>, which is then used to enable all
+        /// of these warnings for default validation during analyzer and code fix tests.
+        /// </summary>
+        internal static ImmutableDictionary<string, ReportDiagnostic> NullableWarnings { get; } = GetNullableWarningsFromCompiler();
+
+        private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
+        {
+            string[] args = { "/warnaserror:nullable" };
+            var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
+            var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
+
+            // Workaround for https://github.com/dotnet/roslyn/issues/41610
+            nullableWarnings = nullableWarnings
+                .SetItem("CS8632", ReportDiagnostic.Error)
+                .SetItem("CS8669", ReportDiagnostic.Error);
+
+            return nullableWarnings;
+        }
+    }
+}


### PR DESCRIPTION
- Also cleaned up `ExportCodeFixProvider`s
- Cleaned up `AccessingTaskResultWithoutAwaitCodeFix`
- New tests should be written with Microsoft's testing library.
- Old tests should be ported as time goes on, and eventually `DiagnosticVerifier` should be deleted.