### PR TITLE
Change `AsyncOverloadsAvailable` to use `IOperation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.16.19] - 2023-01-01
+- `AsyncOverloadsAvailableAnalyzer`: Analyzer is rewritten to use `IOperation`
+
 ## [1.16.18] - 2022-12-31
 - Unit tests target .NET 7 and test framework dependencies have been updated
 - Vsix build tools dependency is updated

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.16.18" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.16.19" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.16.18</PackageVersion>
+    <PackageVersion>1.16.19</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
@@ -38,11 +38,13 @@ public class AsyncOverloadsAvailableAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(OperationBlockAnalysisContext context, INamedTypeSymbol cancellationTokenSymbol)
     {
+        // Problem: if the invocation is done inside a synchronous lambda, it still looks at the surrounding method declaration
         if (context.OwningSymbol is not IMethodSymbol surroundingMethod)
         {
             return;
         }
 
+        // Problem: If the surrounding method is a global statement is it considered as `IsAsync: false` even though async calls work
         if (surroundingMethod is { IsAsync: false })
         {
             return;

--- a/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
@@ -29,14 +29,11 @@ public class AsyncOverloadsAvailableAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationStartAction(compilationContext =>
         {
             var cancellationTokenSymbol = compilationContext.Compilation.GetTypeByMetadataName("System.Threading.CancellationToken");
-            if (cancellationTokenSymbol is not null)
-            {
-                compilationContext.RegisterOperationBlockAction(context => Analyze(context, cancellationTokenSymbol));
-            }
+            compilationContext.RegisterOperationBlockAction(context => Analyze(context, cancellationTokenSymbol));
         });
     }
 
-    private static void Analyze(OperationBlockAnalysisContext context, INamedTypeSymbol cancellationTokenSymbol)
+    private static void Analyze(OperationBlockAnalysisContext context, INamedTypeSymbol? cancellationTokenSymbol)
     {
         if (context.OwningSymbol is not IMethodSymbol surroundingMethod)
         {

--- a/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
@@ -63,8 +63,7 @@ public class AsyncOverloadsAvailableAnalyzer : DiagnosticAnalyzer
             var invokedMethodName = invocation.TargetMethod.Name;
             var invokedTypeName = invocation.TargetMethod.ContainingType.Name;
 
-            var methodsInInvokedType = invocation.TargetMethod.ContainingType.GetMembers().OfType<IMethodSymbol>();
-            var relevantOverloads = methodsInInvokedType.Where(x => x.Name == $"{invokedMethodName}Async");
+            var relevantOverloads = invocation.TargetMethod.ContainingType.GetMembers($"{invokedMethodName}Async").OfType<IMethodSymbol>();
 
             foreach (var overload in relevantOverloads)
             {

--- a/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
@@ -44,8 +44,7 @@ public class AsyncOverloadsAvailableAnalyzer : DiagnosticAnalyzer
         }
 
         // If the surrounding method is a global statement is it considered as `IsAsync: false` even though async calls work
-        // Using CanBeReferencedByName to try and distinguish between the two scenarios since the top-level statements entry point can't be referenced 
-        if (surroundingMethod is { IsAsync: false, CanBeReferencedByName: true })
+        if (surroundingMethod is { IsAsync: false, Name: not WellKnownMemberNames.TopLevelStatementsEntryPointMethodName })
         {
             return;
         }

--- a/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
@@ -43,8 +43,9 @@ public class AsyncOverloadsAvailableAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Problem: If the surrounding method is a global statement is it considered as `IsAsync: false` even though async calls work
-        if (surroundingMethod is { IsAsync: false })
+        // If the surrounding method is a global statement is it considered as `IsAsync: false` even though async calls work
+        // Using CanBeReferencedByName to try and distinguish between the two scenarios since the top-level statements entry point can't be referenced 
+        if (surroundingMethod is { IsAsync: false, CanBeReferencedByName: true })
         {
             return;
         }

--- a/SharpSource/SharpSource/Utilities/Extensions.cs
+++ b/SharpSource/SharpSource/Utilities/Extensions.cs
@@ -204,4 +204,13 @@ public static class Extensions
 
     public static bool PassesThroughCancellationToken(this IInvocationOperation invocation, INamedTypeSymbol cancellationTokenSymbol)
         => invocation.Arguments.Any(argument => cancellationTokenSymbol.Equals(argument.Parameter?.Type, SymbolEqualityComparer.Default));
+
+    public static IEnumerable<IOperation?> Ancestors(this IOperation? operation)
+    {
+        while (operation is not null)
+        {
+            operation = operation.Parent;
+            yield return operation;
+        }
+    }
 }

--- a/SharpSource/SharpSource/Utilities/Extensions.cs
+++ b/SharpSource/SharpSource/Utilities/Extensions.cs
@@ -202,8 +202,8 @@ public static class Extensions
         return default;
     }
 
-    public static bool PassesThroughCancellationToken(this IInvocationOperation invocation, INamedTypeSymbol cancellationTokenSymbol)
-        => invocation.Arguments.Any(argument => cancellationTokenSymbol.Equals(argument.Parameter?.Type, SymbolEqualityComparer.Default));
+    public static bool PassesThroughCancellationToken(this IInvocationOperation invocation, INamedTypeSymbol? cancellationTokenSymbol)
+        => cancellationTokenSymbol != default && invocation.Arguments.Any(argument => cancellationTokenSymbol.Equals(argument.Parameter?.Type, SymbolEqualityComparer.Default));
 
     public static IEnumerable<IOperation?> Ancestors(this IOperation? operation)
     {

--- a/SharpSource/SharpSource/Utilities/Extensions.cs
+++ b/SharpSource/SharpSource/Utilities/Extensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace SharpSource.Utilities;
 
@@ -201,23 +202,6 @@ public static class Extensions
         return default;
     }
 
-    public static bool PassesThroughCancellationToken(this InvocationExpressionSyntax invocation, SemanticModel semanticModel)
-    {
-        foreach (var argument in invocation.ArgumentList.Arguments)
-        {
-            var argumentType = semanticModel.GetTypeInfo(argument.Expression).Type;
-
-            if (argumentType is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } ctoken && ctoken.TypeArguments.Single().Name == "CancellationToken")
-            {
-                return true;
-            }
-
-            if (argumentType is INamedTypeSymbol { Name: "CancellationToken" })
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    public static bool PassesThroughCancellationToken(this IInvocationOperation invocation, INamedTypeSymbol cancellationTokenSymbol)
+        => invocation.Arguments.Any(argument => cancellationTokenSymbol.Equals(argument.Parameter?.Type, SymbolEqualityComparer.Default));
 }


### PR DESCRIPTION
Largely there although two unit tests are still failing. Both relate to the surrounding declaration when it is not a regular method (e.g. a global statement or a synchronous lambda)