### PR TITLE
`StaticInitializerAccessedBeforeInitialization`: Doesn't trigger an error if a member with the same name but in a different type is referenced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ https://keepachangelog.com/en/1.0.0/
 
 ## [1.16.21] - 2023-01-01
 - `StaticInitializerAccessedBeforeInitialization`: Doesn't trigger an error if a member with the same name but in a different type is referenced
+- `TestMethodWithoutPublicModifier`: Now supports custom attributes that inherit from a test attribute
 
 ## [1.16.20] - 2023-01-01
 - `ElementaryMethodsOfTypeInCollectionNotOverridden`: Fixed a `NullReferenceException` when analysing `extern` declarations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.16.21] - 2023-01-01
+- `StaticInitializerAccessedBeforeInitialization`: Doesn't trigger an error if a member with the same name but in a different type is referenced
+
 ## [1.16.20] - 2023-01-01
 - `ElementaryMethodsOfTypeInCollectionNotOverridden`: Fixed a `NullReferenceException` when analysing `extern` declarations
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.16.20" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.16.21" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.16.20</PackageVersion>
+    <PackageVersion>1.16.21</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/Helpers/DiagnosticVerifier.cs
+++ b/SharpSource/SharpSource.Test/Helpers/DiagnosticVerifier.cs
@@ -41,6 +41,7 @@ public abstract class DiagnosticVerifier
     private static readonly MetadataReference NunitReference = MetadataReference.CreateFromFile(typeof(NUnit.Framework.TestFixtureAttribute).Assembly.Location);
     private static readonly MetadataReference MsTestReference = MetadataReference.CreateFromFile(typeof(Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute).Assembly.Location);
     private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+    private static readonly MetadataReference ImmutableReference = MetadataReference.CreateFromFile(typeof(ImmutableHashSet).Assembly.Location);
 
     private static string GetDllDirectory(string dllName) => Path.Combine(Path.GetDirectoryName(SystemPrivateCoreLibPath) ?? "", dllName);
 
@@ -348,7 +349,8 @@ public abstract class DiagnosticVerifier
             AspNetCoreMvc,
             XunitReference,
             MsTestReference,
-            NunitReference
+            NunitReference,
+            ImmutableReference
         };
 
         var compilationOptions = new CSharpCompilationOptions(OutputKind.WindowsApplication).WithAllowUnsafe(true);

--- a/SharpSource/SharpSource.Test/StaticInitializerAccessedBeforeInitializationTests.cs
+++ b/SharpSource/SharpSource.Test/StaticInitializerAccessedBeforeInitializationTests.cs
@@ -538,4 +538,24 @@ partial struct Test
 
         await VerifyDiagnostic(original);
     }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/244")]
+    public async Task StaticInitializerAccessedBeforeInitialization_DifferentTypeSameMemberName()
+    {
+        var original = @"
+using System.Collections.Immutable;
+
+class Other
+{
+    public const string Key = ""Other key"";
+}
+
+class Test
+{
+    public static ImmutableHashSet<string> All = ImmutableHashSet.Create(""first"", Other.Key, ""last"");
+    public static string Key = ""key"";
+}";
+
+        await VerifyDiagnostic(original);
+    }
 }

--- a/SharpSource/SharpSource.Test/TestMethodWithoutPublicModifierTests.cs
+++ b/SharpSource/SharpSource.Test/TestMethodWithoutPublicModifierTests.cs
@@ -366,7 +366,7 @@ namespace ConsoleApplication1
         await VerifyDiagnostic(original);
     }
 
-    [TestMethod]
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/236")]
     public async Task TestMethodWithoutPublicModifier_InheritedAttribute_SingleLevel()
     {
         var original = @"
@@ -405,7 +405,7 @@ public class MyClass
         await VerifyFix(original, result);
     }
 
-    [TestMethod]
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/236")]
     public async Task TestMethodWithoutPublicModifier_InheritedAttribute_MultipleLevels()
     {
         var original = @"

--- a/SharpSource/SharpSource.Test/TestMethodWithoutPublicModifierTests.cs
+++ b/SharpSource/SharpSource.Test/TestMethodWithoutPublicModifierTests.cs
@@ -365,4 +365,43 @@ namespace ConsoleApplication1
 
         await VerifyDiagnostic(original);
     }
+
+    [TestMethod]
+    public async Task TestMethodWithoutPublicModifier_InheritedAttribute()
+    {
+        var original = @"
+using System;
+using NUnit.Framework;
+
+class MyOwnAttribute : TestAttribute {}
+
+[TestFixture]
+public class MyClass
+{
+    [MyOwnAttribute]
+    void Method()
+    {
+
+    }
+}";
+
+        var result = @"
+using System;
+using NUnit.Framework;
+
+class MyOwnAttribute : TestAttribute {}
+
+[TestFixture]
+public class MyClass
+{
+    [MyOwnAttribute]
+    public void Method()
+    {
+
+    }
+}";
+
+        await VerifyDiagnostic(original, "Test method \"Method\" is not public.");
+        await VerifyFix(original, result);
+    }
 }

--- a/SharpSource/SharpSource.Test/TestMethodWithoutPublicModifierTests.cs
+++ b/SharpSource/SharpSource.Test/TestMethodWithoutPublicModifierTests.cs
@@ -367,7 +367,7 @@ namespace ConsoleApplication1
     }
 
     [TestMethod]
-    public async Task TestMethodWithoutPublicModifier_InheritedAttribute()
+    public async Task TestMethodWithoutPublicModifier_InheritedAttribute_SingleLevel()
     {
         var original = @"
 using System;
@@ -395,6 +395,49 @@ class MyOwnAttribute : TestAttribute {}
 public class MyClass
 {
     [MyOwnAttribute]
+    public void Method()
+    {
+
+    }
+}";
+
+        await VerifyDiagnostic(original, "Test method \"Method\" is not public.");
+        await VerifyFix(original, result);
+    }
+
+    [TestMethod]
+    public async Task TestMethodWithoutPublicModifier_InheritedAttribute_MultipleLevels()
+    {
+        var original = @"
+using System;
+using NUnit.Framework;
+
+class MyOwnAttribute : TestAttribute {}
+class MySecondAttribute : MyOwnAttribute {}
+class MyThirdAttribute : MySecondAttribute {}
+
+[TestFixture]
+public class MyClass
+{
+    [MyThird]
+    void Method()
+    {
+
+    }
+}";
+
+        var result = @"
+using System;
+using NUnit.Framework;
+
+class MyOwnAttribute : TestAttribute {}
+class MySecondAttribute : MyOwnAttribute {}
+class MyThirdAttribute : MySecondAttribute {}
+
+[TestFixture]
+public class MyClass
+{
+    [MyThird]
     public void Method()
     {
 


### PR DESCRIPTION
closes #244 
closes #236 