### PR TITLE
`FlagsEnumValuesAreNotPowersOfTwo`: Code fix now formats correctly and doesn't copy comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 https://keepachangelog.com/en/1.0.0/
 
 ## [1.17.3] - 2023-01-03
-- 
+- `FlagsEnumValuesAreNotPowersOfTwo`: Code fix now formats correctly and doesn't copy comments
 
 ## [1.17.2] - 2023-01-02
 - `SynchronousTaskWait`: Now works for top-level statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ https://keepachangelog.com/en/1.0.0/
 
 ## [1.17.3] - 2023-01-03
 - `FlagsEnumValuesAreNotPowersOfTwo`: Code fix now formats correctly and doesn't copy comments
+- `HttpContextStoredInField`: Only triggers if a reference to `Microsoft.AspNetCore.Http.IHttpContextAccessor` exists
 
 ## [1.17.2] - 2023-01-02
 - `SynchronousTaskWait`: Now works for top-level statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ https://keepachangelog.com/en/1.0.0/
 - `HttpContextStoredInField`: Only triggers if a reference to `Microsoft.AspNetCore.Http.IHttpContextAccessor` exists
 - `LockingOnMutableReference`: Now includes the name of the field in the error message
 - Simplified `GetSyntaxRootAsync` calls in code fixes
+- `UnusedResultOnImmutableObject`: Now uses `IOperation`
 
 ## [1.17.2] - 2023-01-02
 - `SynchronousTaskWait`: Now works for top-level statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.17.3] - 2023-01-03
+- 
+
 ## [1.17.2] - 2023-01-02
 - `SynchronousTaskWait`: Now works for top-level statements
 - `SynchronousTaskWait`: Rewritten to use `IOperation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ https://keepachangelog.com/en/1.0.0/
 ## [1.17.3] - 2023-01-03
 - `FlagsEnumValuesAreNotPowersOfTwo`: Code fix now formats correctly and doesn't copy comments
 - `HttpContextStoredInField`: Only triggers if a reference to `Microsoft.AspNetCore.Http.IHttpContextAccessor` exists
+- Simplified `GetSyntaxRootAsync` calls in code fixes
 
 ## [1.17.2] - 2023-01-02
 - `SynchronousTaskWait`: Now works for top-level statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ https://keepachangelog.com/en/1.0.0/
 ## [1.17.3] - 2023-01-03
 - `FlagsEnumValuesAreNotPowersOfTwo`: Code fix now formats correctly and doesn't copy comments
 - `HttpContextStoredInField`: Only triggers if a reference to `Microsoft.AspNetCore.Http.IHttpContextAccessor` exists
+- `LockingOnMutableReference`: Now includes the name of the field in the error message
 - Simplified `GetSyntaxRootAsync` calls in code fixes
 
 ## [1.17.2] - 2023-01-02

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.17.2" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.17.3" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/AccessingTaskResultWithoutAwaitCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/AccessingTaskResultWithoutAwaitCodeFix.cs
@@ -22,16 +22,16 @@ public class AccessingTaskResultWithoutAwaitCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-        var taskResultExpression = root?.FindToken(diagnosticSpan.Start)
+        var taskResultExpression = root.FindToken(diagnosticSpan.Start)
             .Parent?
             .AncestorsAndSelf()
             .OfType<MemberAccessExpressionSyntax>()
             .SingleOrDefault(x => x.Name.Identifier.ValueText == "Result");
 
-        if (root == default || taskResultExpression == default)
+        if (taskResultExpression == default)
         {
             return;
         }

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/AsyncMethodWithVoidReturnTypeCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/AsyncMethodWithVoidReturnTypeCodeFix.cs
@@ -22,13 +22,12 @@ public class AsyncMethodWithVoidReturnTypeCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-        var methodDeclaration =
-            root?.FindToken(diagnosticSpan.Start).Parent?.FirstAncestorOrSelfOfType(SyntaxKind.MethodDeclaration, SyntaxKind.LocalFunctionStatement);
+        var methodDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.FirstAncestorOrSelfOfType(SyntaxKind.MethodDeclaration, SyntaxKind.LocalFunctionStatement);
 
-        if (root == default || methodDeclaration == default)
+        if (methodDeclaration == default)
         {
             return;
         }

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/AsyncOverloadsAvailableCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/AsyncOverloadsAvailableCodeFix.cs
@@ -21,11 +21,7 @@ public class AsyncOverloadsAvailableCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        if (root == default)
-        {
-            return;
-        }
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
         var invocation = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/AttributeMustSpecifyAttributeUsageCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/AttributeMustSpecifyAttributeUsageCodeFix.cs
@@ -20,10 +20,10 @@ public class AttributeMustSpecifyAttributeUsageCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-        var classDeclaration = root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+        var classDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (root is not CompilationUnitSyntax compilation || classDeclaration == default)
         {
             return;

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ComparingStringsWithoutStringComparisonCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ComparingStringsWithoutStringComparisonCodeFix.cs
@@ -19,7 +19,7 @@ public class ComparingStringsWithoutStringComparisonCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var semanticModel = await context.Document.GetSemanticModelAsync().ConfigureAwait(false);
         if (root is not CompilationUnitSyntax compilation || semanticModel == default)
         {

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/DateTimeNowCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/DateTimeNowCodeFix.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Simplification;
+using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
@@ -18,14 +19,9 @@ public class DateTimeNowCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-        if (root == default)
-        {
-            return;
-        }
-
         var statement = root.FindNode(diagnosticSpan, getInnermostNodeForTie: true);
 
         context.RegisterCodeFix(

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/EqualsAndGetHashcodeNotImplementedTogetherCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/EqualsAndGetHashcodeNotImplementedTogetherCodeFix.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
+using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
@@ -20,14 +21,9 @@ public class EqualsAndGetHashcodeNotImplementedTogetherCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-        if (root == default)
-        {
-            return;
-        }
-
         var statement = root.FindNode(diagnosticSpan);
 
         if (bool.Parse(diagnostic.Properties["IsEqualsImplemented"]))

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ExplicitEnumValuesCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ExplicitEnumValuesCodeFix.cs
@@ -22,15 +22,9 @@ public class ExplicitEnumValuesCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-
-        if (root == default)
-        {
-            return;
-        }
-
         var statement = root.FindNode(diagnosticSpan).DescendantNodesAndSelf().OfType<EnumMemberDeclarationSyntax>().First();
 
         context.RegisterCodeFix(

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/FlagsEnumValuesAreNotPowersOfTwoCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/FlagsEnumValuesAreNotPowersOfTwoCodeFix.cs
@@ -22,12 +22,12 @@ public class FlagsEnumValuesAreNotPowersOfTwoCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-        var enumMember = root?.FindNode(diagnosticSpan)?.FirstAncestorOrSelfOfType(SyntaxKind.EnumMemberDeclaration) as EnumMemberDeclarationSyntax;
+        var enumMember = root.FindNode(diagnosticSpan)?.FirstAncestorOrSelfOfType(SyntaxKind.EnumMemberDeclaration) as EnumMemberDeclarationSyntax;
         var semanticModel = await context.Document.GetSemanticModelAsync().ConfigureAwait(false);
-        if (root == default || enumMember == default || semanticModel == default)
+        if (enumMember == default || semanticModel == default)
         {
             return;
         }

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/FlagsEnumValuesAreNotPowersOfTwoCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/FlagsEnumValuesAreNotPowersOfTwoCodeFix.cs
@@ -85,7 +85,7 @@ public class FlagsEnumValuesAreNotPowersOfTwoCodeFix : CodeFixProvider
 
     private static Task<Document> UseBitwiseExpression(Document document, SyntaxNode root, EnumMemberDeclarationSyntax enumMember, SyntaxToken firstIdentifier, SyntaxToken secondIdentifier)
     {
-        var newValue = SyntaxFactory.BinaryExpression(SyntaxKind.BitwiseOrExpression, SyntaxFactory.IdentifierName(firstIdentifier), SyntaxFactory.IdentifierName(secondIdentifier));
+        var newValue = SyntaxFactory.BinaryExpression(SyntaxKind.BitwiseOrExpression, SyntaxFactory.IdentifierName(firstIdentifier.WithoutTrivia()), SyntaxFactory.IdentifierName(secondIdentifier.WithoutTrivia()));
         var newMember = enumMember.WithEqualsValue(SyntaxFactory.EqualsValueClause(newValue)).WithAdditionalAnnotations(Formatter.Annotation);
         var newRoot = root.ReplaceNode(enumMember, newMember);
         var newDocument = document.WithSyntaxRoot(newRoot);

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/LockingOnMutableReferenceCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/LockingOnMutableReferenceCodeFix.cs
@@ -20,12 +20,7 @@ public class LockingOnMutableReferenceCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        if (root == default)
-        {
-            return;
-        }
-
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/NewGuidCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/NewGuidCodeFix.cs
@@ -21,12 +21,7 @@ public class NewGuidCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        if (root == default)
-        {
-            return;
-        }
-
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/OnPropertyChangedWithoutNameOfOperatorCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/OnPropertyChangedWithoutNameOfOperatorCodeFix.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
+using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
@@ -18,13 +19,8 @@ public class OnPropertyChangedWithoutNameOfOperatorCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
-
-        if (root == default)
-        {
-            return;
-        }
 
         context.RegisterCodeFix(
             CodeAction.Create("Use nameof()",

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ParameterAssignedInConstructorCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ParameterAssignedInConstructorCodeFix.cs
@@ -21,12 +21,7 @@ public class ParameterAssignedInConstructorCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        if (root == default)
-        {
-            return;
-        }
-
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
         var assignmentExpression = root.FindNode(diagnosticSpan).AncestorsAndSelf().OfType<AssignmentExpressionSyntax>().First();

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/RethrowExceptionWithoutLosingStacktraceCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/RethrowExceptionWithoutLosingStacktraceCodeFix.cs
@@ -22,14 +22,9 @@ public class RethrowExceptionWithoutLosingStacktraceCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-        if (root == default)
-        {
-            return;
-        }
-
         var throwStatement = root.FindNode(diagnosticSpan).AncestorsAndSelf().OfType<ThrowStatementSyntax>().First();
 
         context.RegisterCodeFix(

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/StringPlaceholdersInWrongOrderCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/StringPlaceholdersInWrongOrderCodeFix.cs
@@ -24,14 +24,9 @@ public class StringPlaceHoldersInWrongOrderCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-
-        if (root == default)
-        {
-            return;
-        }
 
         var stringFormatInvocation =
             root.FindToken(diagnosticSpan.Start)

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/StructWithoutElementaryMethodsOverriddenCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/StructWithoutElementaryMethodsOverriddenCodeFix.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
+using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
 
@@ -23,7 +24,7 @@ public class StructWithoutElementaryMethodsOverriddenCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
@@ -43,9 +44,8 @@ public class StructWithoutElementaryMethodsOverriddenCodeFix : CodeFixProvider
                 {"ToString()", implementToString}
             };
 
-        var statement = root?.FindNode(diagnosticSpan) as StructDeclarationSyntax;
-
-        if (root == default || statement == default)
+        var statement = root.FindNode(diagnosticSpan) as StructDeclarationSyntax;
+        if (statement == default)
         {
             return;
         }

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchDoesNotHandleAllEnumOptionsCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchDoesNotHandleAllEnumOptionsCodeFix.cs
@@ -25,12 +25,12 @@ public class SwitchDoesNotHandleAllEnumOptionsCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
         var semanticModel = await context.Document.GetSemanticModelAsync().ConfigureAwait(false);
 
-        if (semanticModel == default || root == default)
+        if (semanticModel == default)
         {
             return;
         }

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchIsMissingDefaultLabelCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchIsMissingDefaultLabelCodeFix.cs
@@ -24,11 +24,11 @@ public class SwitchIsMissingDefaultLabelCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-        var switchToken = root?.FindNode(diagnosticSpan);
+        var switchToken = root.FindNode(diagnosticSpan);
         var statement = switchToken?.DescendantNodesAndSelf().FirstOfKind<SwitchStatementSyntax>(SyntaxKind.SwitchStatement);
         if (root is not CompilationUnitSyntax compilation || statement == default)
         {

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SynchronousTaskWaitCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SynchronousTaskWaitCodeFix.cs
@@ -21,11 +21,11 @@ public class SynchronousTaskWaitCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-        var synchronousWaitMethod = root?.FindNode(diagnosticSpan, getInnermostNodeForTie: true) as InvocationExpressionSyntax;
+        var synchronousWaitMethod = root.FindNode(diagnosticSpan, getInnermostNodeForTie: true) as InvocationExpressionSyntax;
         var memberAccessExpression = synchronousWaitMethod?.DescendantNodesAndSelfOfType(SyntaxKind.SimpleMemberAccessExpression).FirstOrDefault() as MemberAccessExpressionSyntax;
 
         // If arguments are passed in then we don't want to offer a code fix as there is no straight way to include that functionality.
@@ -34,7 +34,7 @@ public class SynchronousTaskWaitCodeFix : CodeFixProvider
             return;
         }
 
-        if (root == default || synchronousWaitMethod == default || memberAccessExpression == default)
+        if (synchronousWaitMethod == default || memberAccessExpression == default)
         {
             return;
         }

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/TestMethodWithoutPublicModifierCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/TestMethodWithoutPublicModifierCodeFix.cs
@@ -21,15 +21,12 @@ public class TestMethodWithoutPublicModifierCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-        var methodDeclaration =
-            root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
-
-        if (root == default || methodDeclaration == default)
+        var methodDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
+        if (methodDeclaration == default)
         {
             return;
         }

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/ThreadSleepInAsyncMethodCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/ThreadSleepInAsyncMethodCodeFix.cs
@@ -22,13 +22,9 @@ public class ThreadSleepInAsyncMethodCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
-        if (root == default)
-        {
-            return;
-        }
 
         var memberAccess = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First();
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/UnboundedStackallocCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/UnboundedStackallocCodeFix.cs
@@ -20,12 +20,7 @@ public class UnboundedStackallocCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        if (root == default)
-        {
-            return;
-        }
-
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/UnnecessaryEnumerableMaterializationCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/UnnecessaryEnumerableMaterializationCodeFix.cs
@@ -20,12 +20,12 @@ public class UnnecessaryEnumerableMaterializationCodeFix : CodeFixProvider
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics[0];
         var operation = diagnostic.Properties["operation"];
         var semanticModel = await context.Document.GetSemanticModelAsync().ConfigureAwait(false);
 
-        if (root == default || operation == default || semanticModel == default)
+        if (operation == default || semanticModel == default)
         {
             return;
         }

--- a/SharpSource/SharpSource.CodeFixes/Utilities/Extensions.cs
+++ b/SharpSource/SharpSource.CodeFixes/Utilities/Extensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -148,5 +150,16 @@ public static class Extensions
         }
 
         return default;
+    }
+
+    public static async ValueTask<SyntaxNode> GetRequiredSyntaxRootAsync(this Document document, CancellationToken cancellationToken)
+    {
+        if (document.TryGetSyntaxRoot(out var root))
+        {
+            return root;
+        }
+
+        root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        return root ?? throw new InvalidOperationException($"Unable to find a syntax root for document {document.Name}");
     }
 }

--- a/SharpSource/SharpSource.CodeFixes/Utilities/Extensions.cs
+++ b/SharpSource/SharpSource.CodeFixes/Utilities/Extensions.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.17.2</PackageVersion>
+    <PackageVersion>1.17.3</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/FlagsEnumValuesAreNotPowersOfTwoTests.cs
+++ b/SharpSource/SharpSource.Test/FlagsEnumValuesAreNotPowersOfTwoTests.cs
@@ -459,4 +459,48 @@ enum Foo
         await VerifyDiagnostic(original, "Enum Foo.Bop is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.");
         await VerifyFix(original, result);
     }
+
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/260")]
+    public async Task FlagsEnumValuesAreNotPowersOfTwo_FormatsCorrectly()
+    {
+        var original = @"
+using System;
+
+[Flags]
+enum Foo
+{
+    Bar = 0,
+
+    // Option 1
+    Biz = 1,
+
+    // Option 2
+    Baz = 2,
+
+    // Option 3
+    Buz = 3
+}";
+
+        var result = @"
+using System;
+
+[Flags]
+enum Foo
+{
+    Bar = 0,
+
+    // Option 1
+    Biz = 1,
+
+    // Option 2
+    Baz = 2,
+
+    // Option 3
+    Buz = Biz | Baz
+}";
+
+        await VerifyDiagnostic(original, "Enum Foo.Buz is marked as a [Flags] enum but contains a literal value that isn't a power of two. Change the value or use a bitwise OR expression instead.");
+        await VerifyFix(original, result);
+    }
 }

--- a/SharpSource/SharpSource.Test/FlagsEnumValuesAreNotPowersOfTwoTests.cs
+++ b/SharpSource/SharpSource.Test/FlagsEnumValuesAreNotPowersOfTwoTests.cs
@@ -307,7 +307,7 @@ enum Foo
     }
 
     [TestMethod]
-    [Ignore("We need to support binary expressions on top of literals")]
+    [Ignore("We need to support binary expressions on top of literals. See https://github.com/Vannevelj/SharpSource/issues/271")]
     public async Task FlagsEnumValuesAreNotPowersOfTwo_BinaryExpressions()
     {
         var original = @"

--- a/SharpSource/SharpSource.Test/LockingOnMutableReferenceTests.cs
+++ b/SharpSource/SharpSource.Test/LockingOnMutableReferenceTests.cs
@@ -20,26 +20,26 @@ public class LockingOnMutableReferenceTests : DiagnosticVerifier
         var original = @"
 class Test
 {
-    private object _lock = new object();
+    private object _someLock = new object();
 
     void M()
     {
-        lock(_lock) { }
+        lock(_someLock) { }
     }
 }";
 
         var expected = @"
 class Test
 {
-    private readonly object _lock = new object();
+    private readonly object _someLock = new object();
 
     void M()
     {
-        lock(_lock) { }
+        lock(_someLock) { }
     }
 }";
 
-        await VerifyDiagnostic(original, "A lock was obtained on _lock but the field is mutable. This can lead to deadlocks when a new value is assigned.");
+        await VerifyDiagnostic(original, "A lock was obtained on _someLock but the field is mutable. This can lead to deadlocks when a new value is assigned.");
         await VerifyFix(original, expected);
     }
 

--- a/SharpSource/SharpSource.Test/MultipleFromBodyParametersTests.cs
+++ b/SharpSource/SharpSource.Test/MultipleFromBodyParametersTests.cs
@@ -30,7 +30,7 @@ class MyController
     }
 
     [TestMethod]
-    [Ignore("Minimal Web API is not supported yet")]
+    [Ignore("Minimal Web API is not supported yet. See https://github.com/Vannevelj/SharpSource/issues/140")]
     [DataRow("[FromBody]")]
     [DataRow("[FromBodyAttribute]")]
     [DataRow("[Microsoft.AspNetCore.Mvc.FromBody]")]

--- a/SharpSource/SharpSource.Test/UnusedResultOnImmutableObjectTests.cs
+++ b/SharpSource/SharpSource.Test/UnusedResultOnImmutableObjectTests.cs
@@ -254,4 +254,14 @@ static class Extensions
 
         await VerifyDiagnostic(original);
     }
+
+    [TestMethod]
+    public async Task UnusedResultOnImmutableObjectTests_TopLevelStatement()
+    {
+        var original = $@"
+""test"".Trim();
+";
+
+        await VerifyDiagnostic(original, "The result of an operation on an immutable object is unused");
+    }
 }

--- a/SharpSource/SharpSource/Diagnostics/HttpContextStoredInFieldAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/HttpContextStoredInFieldAnalyzer.cs
@@ -27,7 +27,8 @@ public class HttpContextStoredInFieldAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationStartAction(compilationContext =>
         {
             var httpContextSymbol = compilationContext.Compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Http.HttpContext");
-            if (httpContextSymbol is not null)
+            var httpContextAccessorSymbol = compilationContext.Compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Http.IHttpContextAccessor");
+            if (httpContextSymbol is not null && httpContextAccessorSymbol is not null)
             {
                 compilationContext.RegisterSymbolAction(context => AnalyzeCreation(context, httpContextSymbol), SymbolKind.Field);
             }

--- a/SharpSource/SharpSource/Diagnostics/LockingOnMutableReferenceAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/LockingOnMutableReferenceAnalyzer.cs
@@ -12,7 +12,7 @@ public sealed class LockingOnMutableReferenceAnalyzer : DiagnosticAnalyzer
     public static DiagnosticDescriptor Rule => new(
         DiagnosticId.LockingOnMutableReference,
         "A lock was obtained on a mutable field which can lead to deadlocks when a new value is assigned. Mark the field as readonly to prevent re-assignment after a lock is taken.",
-        "A lock was obtained on _lock but the field is mutable. This can lead to deadlocks when a new value is assigned.",
+        "A lock was obtained on {0} but the field is mutable. This can lead to deadlocks when a new value is assigned.",
         Categories.Correctness,
         DiagnosticSeverity.Warning,
         true,

--- a/SharpSource/SharpSource/Diagnostics/UnusedResultOnImmutableObjectAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/UnusedResultOnImmutableObjectAnalyzer.cs
@@ -54,8 +54,7 @@ public class UnusedResultOnImmutableObjectAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (invocation.Syntax.Parent is ExpressionStatementSyntax expressionStatement &&
-            expressionStatement.Parent is BlockSyntax or GlobalStatementSyntax)
+        if (invocation.Parent is IExpressionStatementOperation expressionStatement && expressionStatement.Parent is IBlockOperation)
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation()));
         }

--- a/SharpSource/SharpSource/Diagnostics/UnusedResultOnImmutableObjectAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/UnusedResultOnImmutableObjectAnalyzer.cs
@@ -26,7 +26,7 @@ public class UnusedResultOnImmutableObjectAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
-        
+
         context.RegisterCompilationStartAction(compilationContext =>
         {
             var stringSymbol = compilationContext.Compilation.GetSpecialType(SpecialType.System_String);

--- a/SharpSource/SharpSource/Diagnostics/UnusedResultOnImmutableObjectAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/UnusedResultOnImmutableObjectAnalyzer.cs
@@ -1,10 +1,9 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-
+using Microsoft.CodeAnalysis.Operations;
 using SharpSource.Utilities;
 
 namespace SharpSource.Diagnostics;
@@ -12,8 +11,6 @@ namespace SharpSource.Diagnostics;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class UnusedResultOnImmutableObjectAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly HashSet<string> AllowedInvocations = new() { "CopyTo", "TryCopyTo" };
-
     public static DiagnosticDescriptor Rule => new(
         DiagnosticId.UnusedResultOnImmutableObject,
         "The result of an operation on an immutable object is unused",
@@ -29,38 +26,38 @@ public class UnusedResultOnImmutableObjectAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
-        context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.InvocationExpression);
+        
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var stringSymbol = compilationContext.Compilation.GetSpecialType(SpecialType.System_String);
+            var allowedInvocations = stringSymbol.GetMembers("CopyTo").Concat(stringSymbol.GetMembers("TryCopyTo")).OfType<IMethodSymbol>().ToArray();
+
+            compilationContext.RegisterOperationAction(context => Analyze(context, allowedInvocations), OperationKind.Invocation);
+        });
     }
 
-    private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+    private static void Analyze(OperationAnalysisContext context, IMethodSymbol[] allowedInvocations)
     {
-        var invocation = (InvocationExpressionSyntax)context.Node;
-        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        var invocation = (IInvocationOperation)context.Operation;
+        if (invocation.Instance?.Type?.SpecialType is not SpecialType.System_String)
         {
             return;
         }
 
-        var typeBeingAccessed = context.SemanticModel.GetTypeInfo(memberAccess.Expression).Type;
-        if (typeBeingAccessed == null || typeBeingAccessed.SpecialType != SpecialType.System_String)
+        if (allowedInvocations.Any(i => i.Equals(invocation.TargetMethod, SymbolEqualityComparer.Default)))
         {
             return;
         }
 
-        if (AllowedInvocations.Contains(memberAccess.Name.Identifier.ValueText))
+        if (invocation.TargetMethod.IsExtensionMethod && !invocation.TargetMethod.IsDefinedInSystemAssembly())
         {
             return;
         }
 
-        if (context.SemanticModel.GetSymbolInfo(memberAccess.Name).Symbol is not IMethodSymbol methodBeingInvoked ||
-           ( methodBeingInvoked.IsExtensionMethod && !methodBeingInvoked.IsDefinedInSystemAssembly() ))
-        {
-            return;
-        }
-
-        if (invocation.Parent is ExpressionStatementSyntax expressionStatement &&
+        if (invocation.Syntax.Parent is ExpressionStatementSyntax expressionStatement &&
             expressionStatement.Parent is BlockSyntax or GlobalStatementSyntax)
         {
-            context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+            context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation()));
         }
     }
 }


### PR DESCRIPTION
closes #260 
closes #254 
closes #239 
closes #257 