### PR TITLE
`AccessingTaskResultWithoutAwait`: Now also shows a warning when the method is not `async` but returns a `Task`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
-## [1.19.2] - 2023-01-16
+## [1.20.0] - 2023-01-17
+- `CollectionManipulatedDuringTraversal`: A collection was modified while it was being iterated over. Make a copy first or avoid iterations while the loop is in progress to avoid an `InvalidOperationException` exception at runtime
 - `AccessingTaskResultWithoutAwait`: Now also shows a warning when the method is not `async` but returns a `Task`
 
 ## [1.19.1] - 2023-01-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
-## [1.20.0] - 2023-01-17
+## [1.20.0] - 2023-01-21
 - `CollectionManipulatedDuringTraversal`: A collection was modified while it was being iterated over. Make a copy first or avoid iterations while the loop is in progress to avoid an `InvalidOperationException` exception at runtime
 - `AccessingTaskResultWithoutAwait`: Now also shows a warning when the method is not `async` but returns a `Task`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.19.2] - 2023-01-16
+- `AccessingTaskResultWithoutAwait`: Now also shows a warning when the method is not `async` but returns a `Task`
+
 ## [1.19.1] - 2023-01-14
 - `PointlessCollectionToString`: Supports immutable collections
 - `StructWithoutElementaryMethodsOverridden`: No longer generates the elementary methods in both declarations if it is a `partial struct`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.19.2" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.20.0" PrivateAssets="All" />
 </ItemGroup>
 ```
 
@@ -89,6 +89,7 @@ Detailed explanations of each analyzer can be found in the documentation: https:
 | SS054  | NewtonsoftMixedWithSystemTextJson |
 | SS055  | MultipleOrderByCalls |
 | SS056  | FormReadSynchronously |
+| SS057  | CollectionManipulatedDuringTraversal |
 
 ## Configuration
 Is a particular rule not to your liking? There are many ways to adjust their severity and even disable them altogether. For an overview of some of the options, check out [this document](https://docs.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.19.1" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.19.2" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/AccessingTaskResultWithoutAwaitCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/AccessingTaskResultWithoutAwaitCodeFix.cs
@@ -41,6 +41,11 @@ public class AccessingTaskResultWithoutAwaitCodeFix : CodeFixProvider
             return;
         }
 
+        if (diagnostic.Properties.TryGetValue("isAsync", out var value) && value == "false")
+        {
+            return;
+        }
+
         context.RegisterCodeFix(
             CodeAction.Create("Use await",
                 _ => UseAwait(context.Document, taskResultExpression, root),

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.19.2</PackageVersion>
+    <PackageVersion>1.20.0</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.19.1</PackageVersion>
+    <PackageVersion>1.19.2</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/AccessingTaskResultWithoutAwaitTests.cs
+++ b/SharpSource/SharpSource.Test/AccessingTaskResultWithoutAwaitTests.cs
@@ -55,7 +55,6 @@ namespace ConsoleApplication1
     {
         var original = @"
 using System;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ConsoleApplication1
@@ -64,7 +63,7 @@ namespace ConsoleApplication1
     {   
         Task MyMethod()
         {
-            var number = Other().Result;
+            var number = {|#0:Other().Result|};
             return Task.CompletedTask;
         }
 
@@ -72,7 +71,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        await VerifyCS.VerifyNoDiagnostic(original);
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Use await to get the result of a Task."));
     }
 
     [TestMethod]
@@ -237,13 +236,13 @@ namespace ConsoleApplication1
 {
     class MyClass
     {
-	    Action MyMethod() => new Action(() => Console.Write(Other().Result));
+	    Action MyMethod() => new Action(() => Console.Write({|#0:Other().Result|}));
 
 	    async Task<int> Other() => 5;
     }
 }";
 
-        await VerifyCS.VerifyCodeFix(original, original);
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Use await to get the result of a Task."));
     }
 
     [TestMethod]
@@ -260,14 +259,14 @@ namespace ConsoleApplication1
     {   
         MyClass()
         {
-            var number = Other().Result;
+            var number = {|#0:Other().Result|};
         }
 
         async Task<int> Other() => 5;
     }
 }";
 
-        await VerifyCS.VerifyNoDiagnostic(original);
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Use await to get the result of a Task."));
     }
 
     [TestMethod]

--- a/SharpSource/SharpSource.Test/CollectionManipulatedDuringTraversalTests.cs
+++ b/SharpSource/SharpSource.Test/CollectionManipulatedDuringTraversalTests.cs
@@ -1,0 +1,489 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using VerifyCS = SharpSource.Test.CSharpCodeFixVerifier<SharpSource.Diagnostics.CollectionManipulatedDuringTraversal, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace SharpSource.Test;
+
+[TestClass]
+public class CollectionManipulatedDuringTraversalTests
+{
+    [TestMethod]
+    [DataRow("Add(item)")]
+    [DataRow("Remove(item)")]
+    [DataRow("Insert(0, item)")]
+    [DataRow("AddRange(new[] { item })")]
+    [DataRow("Clear()")]
+    [DataRow("InsertRange(0, new[] { item })")]
+    [DataRow("RemoveAll(x => true)")]
+    [DataRow("RemoveAt(0)")]
+    [DataRow("RemoveRange(0, 1)")]
+    [DataRow("Reverse()")]
+    [DataRow("Sort()")]
+    public async Task CollectionManipulatedDuringTraversal_List(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_ReAssign()
+    {
+        var original = @"
+using System.Collections.Generic;
+using System.Linq;
+
+void Method(IEnumerable<int> items)
+{
+    foreach (var item in items)
+    {
+        items = items.Append(5);
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_NonManipulation()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    foreach (var item in items)
+    {
+        items.LastIndexOf(item);
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_OnCopy()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    foreach (var item in items.ToArray())
+    {
+        items.LastIndexOf(item);
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_ModifiesOtherReference_ForEach()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    var copy = items.ToArray();
+    foreach (var item in copy)
+    {
+        items.Add(item);
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_ModifiesProperty()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+class Test
+{
+    public List<int> Items { get; set; }
+
+    void Method()
+    {
+        foreach (var item in Items)
+        {
+            {|#0:Items.Add(item)|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_ModifiesOtherReference_For()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    var copy = items.ToArray();
+    for (var i = 0; i < copy.Length; i++)
+    {
+        items.Add(items[i]);
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_ReferencesComplex()
+    {
+        var original = @"
+using System.Collections.Generic;
+using System.Linq;
+
+void Method(List<int> items)
+{
+    var copy = items.ToArray();
+    foreach (var item in copy.Concat(items))
+    {
+        {|#0:items.Add(item)|};
+    }
+}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Add(0, 5)")]
+    [DataRow("Clear()")]
+    [DataRow("Remove(32)")]
+    [DataRow("TryAdd(1, 2)")]
+    public async Task CollectionManipulatedDuringTraversal_Dictionary(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(Dictionary<int, int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Add(0)")]
+    [DataRow("Clear()")]
+    [DataRow("ExceptWith(new int[] { })")]
+    [DataRow("IntersectWith(new int[] { })")]
+    [DataRow("Remove(0)")]
+    [DataRow("RemoveWhere(x => true)")]
+    [DataRow("SymmetricExceptWith(new int[] { })")]
+    [DataRow("UnionWith(new int[] { })")]
+    public async Task CollectionManipulatedDuringTraversal_HashSet(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(HashSet<int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Clear()")]
+    [DataRow("Pop()")]
+    [DataRow("Push(1)")]
+    [DataRow("TryPop(out var result)")]
+    public async Task CollectionManipulatedDuringTraversal_Stack(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(Stack<int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Clear()")]
+    [DataRow("Dequeue()")]
+    [DataRow("Enqueue(1)")]
+    [DataRow("TryDequeue(out var result)")]
+    public async Task CollectionManipulatedDuringTraversal_Queue(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(Queue<int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Add(0, 5)")]
+    [DataRow("Clear()")]
+    [DataRow("Remove(32)")]
+    public async Task CollectionManipulatedDuringTraversal_SortedDictionary(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(SortedDictionary<int, int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Add(0, 2)")]
+    [DataRow("Remove(0)")]
+    [DataRow("RemoveAt(0)")]
+    //[DataRow("SetValueAtIndex(0, 32)")] // .NET 7
+    public async Task CollectionManipulatedDuringTraversal_SortedList(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(SortedList<int, int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Add(0)")]
+    [DataRow("Clear()")]
+    [DataRow("ExceptWith(new int[] { })")]
+    [DataRow("IntersectWith(new int[] { })")]
+    [DataRow("Remove(0)")]
+    [DataRow("RemoveWhere(x => true)")]
+    [DataRow("Reverse()")]
+    [DataRow("SymmetricExceptWith(new int[] { })")]
+    [DataRow("UnionWith(new int[] { })")]
+    public async Task CollectionManipulatedDuringTraversal_SortedSet(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(SortedSet<int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Add(0)")]
+    [DataRow("Clear()")]
+    [DataRow("Remove(0)")]
+    public async Task CollectionManipulatedDuringTraversal_ICollection(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(ICollection<int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Insert(0, 2)")]
+    [DataRow("RemoveAt(0)")]
+    public async Task CollectionManipulatedDuringTraversal_IList(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(IList<int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Add(0)")]
+    [DataRow("ExceptWith(new int[] { })")]
+    [DataRow("IntersectWith(new int[] { })")]
+    [DataRow("SymmetricExceptWith(new int[] { })")]
+    [DataRow("UnionWith(new int[] { })")]
+    public async Task CollectionManipulatedDuringTraversal_ISet(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(ISet<int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    [DataRow("Add(0, 5)")]
+    [DataRow("Remove(32)")]
+    public async Task CollectionManipulatedDuringTraversal_IDictionary(string invocation)
+    {
+        var original = $@"
+using System.Collections.Generic;
+
+void Method(IDictionary<int, int> items)
+{{
+    foreach (var item in items)
+    {{
+        {{|#0:items.{invocation}|}};
+    }}
+}}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_Array()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+void Method(int[] items)
+{
+    foreach (var item in items)
+    {
+        items.SetValue(null, 1);
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_For()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    for (var i = 0; i < items.Count; i++)
+    {
+        {|#0:items.Add(0)|};
+    }
+}";
+
+        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection."));
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_Indexer()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    for (var i = 0; i < items.Count; i++)
+    {
+        items[i] = 32;
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_While()
+    {
+        var original = @"
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    while (true)
+    {
+        items.Add(0);
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task CollectionManipulatedDuringTraversal_Lambda()
+    {
+        var original = @"
+using System;
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    Action thing;
+    foreach (var item in items)
+    {
+        thing = () => items.Add(item);
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+}

--- a/SharpSource/SharpSource.Test/CollectionManipulatedDuringTraversalTests.cs
+++ b/SharpSource/SharpSource.Test/CollectionManipulatedDuringTraversalTests.cs
@@ -527,40 +527,4 @@ void Method(List<int> items)
 
         await VerifyCS.VerifyNoDiagnostic(original);
     }
-
-    [TestMethod]
-    public async Task CollectionManipulatedDuringTraversal_WithSubsequentReturn()
-    {
-        var original = @"
-using System.Collections.Generic;
-
-void Method(List<int> items)
-{
-    foreach (var item in items)
-    {
-        items.Add(1);
-        return;
-    }
-}";
-
-        await VerifyCS.VerifyNoDiagnostic(original);
-    }
-
-    [TestMethod]
-    public async Task CollectionManipulatedDuringTraversal_WithSubsequentBreak()
-    {
-        var original = @"
-using System.Collections.Generic;
-
-void Method(List<int> items)
-{
-    foreach (var item in items)
-    {
-        items.Add(1);
-        break;
-    }
-}";
-
-        await VerifyCS.VerifyNoDiagnostic(original);
-    }
 }

--- a/SharpSource/SharpSource/Diagnostics/AccessingTaskResultWithoutAwaitAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/AccessingTaskResultWithoutAwaitAnalyzer.cs
@@ -67,9 +67,7 @@ public sealed class AccessingTaskResultWithoutAwaitAnalyzer : DiagnosticAnalyzer
             operation = operation.Parent;
         }
 
-        if (isAsyncContext)
-        {
-            context.ReportDiagnostic(Diagnostic.Create(Rule, context.Operation.Syntax.GetLocation()));
-        }
+        var properties = ImmutableDictionary<string, string?>.Empty.Add("isAsync", isAsyncContext ? "true" : "false");
+        context.ReportDiagnostic(Diagnostic.Create(Rule, context.Operation.Syntax.GetLocation(), properties));
     }
 }

--- a/SharpSource/SharpSource/Diagnostics/CollectionManipulatedDuringTraversal.cs
+++ b/SharpSource/SharpSource/Diagnostics/CollectionManipulatedDuringTraversal.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using SharpSource.Utilities;
+
+namespace SharpSource.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CollectionManipulatedDuringTraversal : DiagnosticAnalyzer
+{
+    public static DiagnosticDescriptor Rule => new(
+        DiagnosticId.CollectionManipulatedDuringTraversal,
+        "A collection was modified while it was being iterated over. Make a copy first or avoid iterations while the loop is in progress to avoid an InvalidOperationException exception at runtime",
+        "Attempted to manipulate a collection while traversing. Ensure modifications don't affect the original collection.",
+        Categories.Correctness,
+        DiagnosticSeverity.Warning,
+        true,
+        helpLinkUri: "https://github.com/Vannevelj/SharpSource/blob/master/docs/SS057-CollectionManipulatedDuringTraversal.md");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var listSymbol = compilationContext.Compilation.GetTypeByMetadataName("System.Collections.Generic.List`1");
+            var setSymbol = compilationContext.Compilation.GetTypeByMetadataName("System.Collections.Generic.List`1");
+
+            IEnumerable<ISymbol> getSymbols(string metadataName, params string[] methods)
+            {
+                return compilationContext.Compilation.GetTypeByMetadataName(metadataName)?.GetAllMembers(methods) ?? Enumerable.Empty<ISymbol>();
+            }
+
+            var allProhibitedMethods = Enumerable.Empty<ISymbol>()
+                                            .Concat(getSymbols("System.Collections.Generic.List`1", "Add", "Remove", "Insert", "AddRange", "Clear", "InsertRange", "RemoveAll", "RemoveAt", "RemoveRange", "Reverse", "Sort"))
+                                            .Concat(getSymbols("System.Collections.Generic.Dictionary`2", "Add", "Clear", "Remove", "TryAdd"))
+                                            .Concat(getSymbols("System.Collections.Generic.HashSet`1", "Add", "Clear", "ExceptWith", "IntersectWith", "Remove", "RemoveWhere", "SymmetricExceptWith", "UnionWith"))
+                                            .Concat(getSymbols("System.Collections.Generic.Stack`1", "Clear", "Pop", "Push", "TryPop"))
+                                            .Concat(getSymbols("System.Collections.Generic.Queue`1", "Clear", "Dequeue", "Enqueue", "TryDequeue"))
+                                            .Concat(getSymbols("System.Collections.Generic.SortedDictionary`2", "Add", "Clear", "Remove"))
+                                            .Concat(getSymbols("System.Collections.Generic.SortedList`2", "Add", "Remove", "RemoveAt", "SetValueAtIndex"))
+                                            .Concat(getSymbols("System.Collections.Generic.SortedSet`1", "Add", "Clear", "ExceptWith", "IntersectWith", "Remove", "RemoveWhere", "Reverse", "SymmetricExceptWith", "UnionWith"))
+                                            .Concat(getSymbols("System.Collections.Generic.ICollection`1", "Add", "Clear", "Remove"))
+                                            .Concat(getSymbols("System.Collections.Generic.IList`1", "Insert", "RemoveAt"))
+                                            .Concat(getSymbols("System.Collections.Generic.ISet`1", "Add", "ExceptWith", "IntersectWith", "SymmetricExceptWith", "UnionWith"))
+                                            .Concat(getSymbols("System.Collections.Generic.IDictionary`2", "Add", "Remove"))
+                                            .OfType<IMethodSymbol>()
+                                            .ToArray();
+
+            if (allProhibitedMethods is { Length: > 0 })
+            {
+                compilationContext.RegisterOperationAction(context => Analyze(context, allProhibitedMethods), OperationKind.Loop);
+            }
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, IMethodSymbol[] prohibitedInvocations)
+    {
+        var loopOperation = (ILoopOperation)context.Operation;
+        if (loopOperation.LoopKind is not ( LoopKind.For or LoopKind.ForEach ))
+        {
+            return;
+        }
+
+        foreach (var invocation in loopOperation.Body.Descendants().TakeWhile(d => d.Kind is not OperationKind.AnonymousFunction).OfType<IInvocationOperation>())
+        {
+            if (prohibitedInvocations.Any(i => invocation.TargetMethod.OriginalDefinition.Equals(i, SymbolEqualityComparer.Default)))
+            {
+                var invokedSymbol = GetReferencedSymbol(invocation.Instance);
+                if (invokedSymbol == default)
+                {
+                    continue;
+                }
+
+                var isTargettingLoopedCollection = loopOperation switch
+                {
+                    IForEachLoopOperation foreachLoop => foreachLoop.Collection.DescendantsAndSelf().Any(d => invokedSymbol.Equals(GetReferencedSymbol(d), SymbolEqualityComparer.Default)),
+                    IForLoopOperation forLoop => forLoop.Condition.DescendantsAndSelf().Any(d => invokedSymbol.Equals(GetReferencedSymbol(d), SymbolEqualityComparer.Default)),
+                    _ => false
+                };
+
+                if (isTargettingLoopedCollection)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation()));
+                }
+            }
+        }
+    }
+
+    private static ISymbol? GetReferencedSymbol(IOperation? operation) => operation switch
+    {
+        ILocalReferenceOperation localRef => localRef.Local,
+        IParameterReferenceOperation paramRef => paramRef.Parameter,
+        IFieldReferenceOperation fieldRef => fieldRef.Field,
+        IMemberReferenceOperation memberRef => memberRef.Member,
+        _ => default
+    };
+}

--- a/SharpSource/SharpSource/Diagnostics/CollectionManipulatedDuringTraversal.cs
+++ b/SharpSource/SharpSource/Diagnostics/CollectionManipulatedDuringTraversal.cs
@@ -38,20 +38,20 @@ public class CollectionManipulatedDuringTraversal : DiagnosticAnalyzer
             }
 
             var allProhibitedMethods = Enumerable.Empty<ISymbol>()
-                                            .Concat(getSymbols("System.Collections.Generic.List`1", "Add", "Remove", "Insert", "AddRange", "Clear", "InsertRange", "RemoveAll", "RemoveAt", "RemoveRange", "Reverse", "Sort"))
-                                            .Concat(getSymbols("System.Collections.Generic.Dictionary`2", "Add", "Clear", "Remove", "TryAdd"))
-                                            .Concat(getSymbols("System.Collections.Generic.HashSet`1", "Add", "Clear", "ExceptWith", "IntersectWith", "Remove", "RemoveWhere", "SymmetricExceptWith", "UnionWith"))
-                                            .Concat(getSymbols("System.Collections.Generic.Stack`1", "Clear", "Pop", "Push", "TryPop"))
-                                            .Concat(getSymbols("System.Collections.Generic.Queue`1", "Clear", "Dequeue", "Enqueue", "TryDequeue"))
-                                            .Concat(getSymbols("System.Collections.Generic.SortedDictionary`2", "Add", "Clear", "Remove"))
-                                            .Concat(getSymbols("System.Collections.Generic.SortedList`2", "Add", "Remove", "RemoveAt", "SetValueAtIndex"))
-                                            .Concat(getSymbols("System.Collections.Generic.SortedSet`1", "Add", "Clear", "ExceptWith", "IntersectWith", "Remove", "RemoveWhere", "Reverse", "SymmetricExceptWith", "UnionWith"))
-                                            .Concat(getSymbols("System.Collections.Generic.ICollection`1", "Add", "Clear", "Remove"))
-                                            .Concat(getSymbols("System.Collections.Generic.IList`1", "Insert", "RemoveAt"))
-                                            .Concat(getSymbols("System.Collections.Generic.ISet`1", "Add", "ExceptWith", "IntersectWith", "SymmetricExceptWith", "UnionWith"))
-                                            .Concat(getSymbols("System.Collections.Generic.IDictionary`2", "Add", "Remove"))
-                                            .OfType<IMethodSymbol>()
-                                            .ToArray();
+                .Concat(getSymbols("System.Collections.Generic.List`1", "Add", "Remove", "Insert", "AddRange", "Clear", "InsertRange", "RemoveAll", "RemoveAt", "RemoveRange", "Reverse", "Sort"))
+                .Concat(getSymbols("System.Collections.Generic.Dictionary`2", "Add", "Clear", "Remove", "TryAdd"))
+                .Concat(getSymbols("System.Collections.Generic.HashSet`1", "Add", "Clear", "ExceptWith", "IntersectWith", "Remove", "RemoveWhere", "SymmetricExceptWith", "UnionWith"))
+                .Concat(getSymbols("System.Collections.Generic.Stack`1", "Clear", "Pop", "Push", "TryPop"))
+                .Concat(getSymbols("System.Collections.Generic.Queue`1", "Clear", "Dequeue", "Enqueue", "TryDequeue"))
+                .Concat(getSymbols("System.Collections.Generic.SortedDictionary`2", "Add", "Clear", "Remove"))
+                .Concat(getSymbols("System.Collections.Generic.SortedList`2", "Add", "Remove", "RemoveAt", "SetValueAtIndex"))
+                .Concat(getSymbols("System.Collections.Generic.SortedSet`1", "Add", "Clear", "ExceptWith", "IntersectWith", "Remove", "RemoveWhere", "Reverse", "SymmetricExceptWith", "UnionWith"))
+                .Concat(getSymbols("System.Collections.Generic.ICollection`1", "Add", "Clear", "Remove"))
+                .Concat(getSymbols("System.Collections.Generic.IList`1", "Insert", "RemoveAt"))
+                .Concat(getSymbols("System.Collections.Generic.ISet`1", "Add", "ExceptWith", "IntersectWith", "SymmetricExceptWith", "UnionWith"))
+                .Concat(getSymbols("System.Collections.Generic.IDictionary`2", "Add", "Remove"))
+                .OfType<IMethodSymbol>()
+                .ToArray();
 
             if (allProhibitedMethods is { Length: > 0 })
             {

--- a/SharpSource/SharpSource/Utilities/DiagnosticId.cs
+++ b/SharpSource/SharpSource/Utilities/DiagnosticId.cs
@@ -55,4 +55,5 @@ public static class DiagnosticId
     public const string NewtonsoftMixedWithSystemTextJson = "SS054";
     public const string MultipleOrderByCalls = "SS055";
     public const string FormReadSynchronously = "SS056";
+    public const string CollectionManipulatedDuringTraversal = "SS057";
 }

--- a/SharpSource/SharpSource/Utilities/Extensions.cs
+++ b/SharpSource/SharpSource/Utilities/Extensions.cs
@@ -220,4 +220,16 @@ public static class Extensions
                  .AllInterfaces
                  .SelectMany(@interface => @interface.GetMembers().OfType<IMethodSymbol>())
                  .Any(interfaceMethod => method.ContainingType.FindImplementationForInterfaceMember(interfaceMethod)?.Equals(method, SymbolEqualityComparer.Default) == true);
+
+    public static IEnumerable<ISymbol> GetAllMembers(this INamespaceOrTypeSymbol symbol, params string[] members)
+    {
+        foreach (var member in members)
+        {
+            var symbolMembers = symbol.GetMembers(member);
+            foreach (var symbolMember in symbolMembers)
+            {
+                yield return symbolMember;
+            }
+        }
+    }
 }

--- a/docs/SS057-CollectionManipulatedDuringTraversal.md
+++ b/docs/SS057-CollectionManipulatedDuringTraversal.md
@@ -1,0 +1,22 @@
+# SS057 - CollectionManipulatedDuringTraversal
+
+[![Generic badge](https://img.shields.io/badge/Severity-Warning-yellow.svg)](https://shields.io/) [![Generic badge](https://img.shields.io/badge/CodeFix-No-lightgrey.svg)](https://shields.io/)
+
+---
+
+A collection was modified while it was being iterated over. Make a copy first or avoid iterations while the loop is in progress to avoid an `InvalidOperationException` exception at runtime
+
+---
+
+## Violation
+```cs
+using System.Collections.Generic;
+
+void Method(List<int> items)
+{
+    foreach (var item in items)
+    {
+        items.Remove(0);
+    }
+}
+```


### PR DESCRIPTION
closes #47 
closes #219 