### PR TITLE
`StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.21.4] - 2023-01-29
+- `StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning
+
 ## [1.21.3] - 2023-01-25
 - `LoopedRandomInstantiation`: No longer triggers when a seed is passed to the constructor
 - `RecursiveOperatorOverload`: No longer triggers multiple identical warnings if the operator is invoked multiple times in the body
@@ -17,7 +20,7 @@ https://keepachangelog.com/en/1.0.0/
 
 ## [1.21.1] - 2023-01-22
 - `StringConcatenatedInLoop`: No longer triggers for regular assignments
-- `UnnecessaryEnumerableMaterialization`: now supports conditional access, i.e. `values?.ToArray().ToList()`
+- `UnnecessaryEnumerableMaterialization`: Now supports conditional access, i.e. `values?.ToArray().ToList()`
 - `AsyncOverloadsAvailable`: No longer triggers when contained within a `lock` body
 - `AsyncOverloadsAvailable`: Better maintains whitespace, indentation and comments when the code fix is applied
 - `AsyncOverloadsAvailable`: Improved the detection of overloads when an optional `CancellationToken` is accepted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ https://keepachangelog.com/en/1.0.0/
 - `StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning
 - `StringConcatenatedInLoop`: Does not trigger when assigning to the loop variable
 - `UnnecessaryEnumerableMaterialization`: Now correctly parses the two subsequent invocations, avoiding issues when they are nested within a method call themselves
+- `SwitchDoesNotHandleAllEnumOptions`: Code Fix generates more predictable code when simplification is possible
+- `SwitchDoesNotHandleAllEnumOptions`: Performance of Code Fix has been improved
 
 ## [1.21.3] - 2023-01-25
 - `LoopedRandomInstantiation`: No longer triggers when a seed is passed to the constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ https://keepachangelog.com/en/1.0.0/
 
 ## [1.21.4] - 2023-01-29
 - `StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning
+- `StringConcatenatedInLoop`: Does not trigger when assigning to the loop variable
 
 ## [1.21.3] - 2023-01-25
 - `LoopedRandomInstantiation`: No longer triggers when a seed is passed to the constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ https://keepachangelog.com/en/1.0.0/
 ## [1.21.4] - 2023-01-29
 - `StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning
 - `StringConcatenatedInLoop`: Does not trigger when assigning to the loop variable
+- `UnnecessaryEnumerableMaterialization`: Now correctly parses the two subsequent invocations, avoiding issues when they are nested within a method call themselves
 
 ## [1.21.3] - 2023-01-25
 - `LoopedRandomInstantiation`: No longer triggers when a seed is passed to the constructor

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.21.3" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.21.4" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchDoesNotHandleAllEnumOptionsCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchDoesNotHandleAllEnumOptionsCodeFix.cs
@@ -10,9 +10,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-
 using SharpSource.Utilities;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace SharpSource.Diagnostics;
 

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.21.3</PackageVersion>
+    <PackageVersion>1.21.4</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/StringConcatenatedInLoopTests.cs
+++ b/SharpSource/SharpSource.Test/StringConcatenatedInLoopTests.cs
@@ -255,4 +255,69 @@ class Test
 
         await VerifyCS.VerifyNoDiagnostic(original);
     }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/309")]
+    public async Task StringConcatenatedInLoop_AssignmentToLoopVariable()
+    {
+        var original = @"
+void Method(Test[] tests)
+{
+    foreach (var test in tests)
+    {
+        test.Id += ""_"" + ""hello"";
+    }
+}
+
+class Test
+{
+    public string Id { get; set; }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task StringConcatenatedInLoop_AssignmentToLoopVariable_Field()
+    {
+        var original = @"
+void Method(Test[] tests)
+{
+    foreach (var test in tests)
+    {
+        test._id += ""_"" + ""hello"";
+    }
+}
+
+class Test
+{
+    public string _id;
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task StringConcatenatedInLoop_AssignmentToLoopVariable_Nested()
+    {
+        var original = @"
+void Method(Test[] tests)
+{
+    foreach (var test in tests)
+    {
+        test.Id.Id += ""_"" + ""hello"";
+    }
+}
+
+class Test
+{
+    public TestTwo Id { get; set; } = new();
+}
+
+class TestTwo
+{
+    public string Id { get; set; }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
 }

--- a/SharpSource/SharpSource.Test/StringConcatenatedInLoopTests.cs
+++ b/SharpSource/SharpSource.Test/StringConcatenatedInLoopTests.cs
@@ -9,7 +9,7 @@ namespace SharpSource.Test;
 public class StringConcatenatedInLoopTests
 {
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_ForEach()
+    public async Task StringConcatenatedInLoop_ForEach()
     {
         var original = @"
 using System.Linq;
@@ -25,7 +25,7 @@ foreach (var item in Enumerable.Empty<int>())
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_For()
+    public async Task StringConcatenatedInLoop_For()
     {
         var original = @"
 var res = string.Empty;
@@ -39,7 +39,7 @@ for (var i = 0; i < 10; i++)
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_While()
+    public async Task StringConcatenatedInLoop_While()
     {
         var original = @"
 var res = string.Empty;
@@ -53,7 +53,7 @@ while (true)
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_DoWhile()
+    public async Task StringConcatenatedInLoop_DoWhile()
     {
         var original = @"
 var res = string.Empty;
@@ -67,7 +67,7 @@ do
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_ScopedInsideLoop()
+    public async Task StringConcatenatedInLoop_ScopedInsideLoop()
     {
         var original = @"
 while (true)
@@ -81,7 +81,7 @@ while (true)
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_OutsideLoop()
+    public async Task StringConcatenatedInLoop_OutsideLoop()
     {
         var original = @"
 while (true)
@@ -96,7 +96,7 @@ res += ""test"";
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_ReferencesProperty()
+    public async Task StringConcatenatedInLoop_ReferencesProperty()
     {
         var original = @"
 class Test
@@ -117,7 +117,7 @@ class Test
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_NonCompoundOperator()
+    public async Task StringConcatenatedInLoop_NonCompoundOperator()
     {
         var original = @"
 var res = string.Empty;
@@ -131,7 +131,7 @@ while (true)
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_NonStringType()
+    public async Task StringConcatenatedInLoop_NonStringType()
     {
         var original = @"
 var res = 0;
@@ -145,7 +145,7 @@ while (true)
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_NoBodyBraces()
+    public async Task StringConcatenatedInLoop_NoBodyBraces()
     {
         var original = @"
 var res = string.Empty;
@@ -157,7 +157,7 @@ while (true)
     }
 
     [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/290")]
-    public async Task StringConcatenatedInLoopTests_NoConcatenation()
+    public async Task StringConcatenatedInLoop_NoConcatenation()
     {
         var original = @"
 var res = string.Empty;
@@ -171,7 +171,7 @@ while (true)
     }
 
     [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/290")]
-    public async Task StringConcatenatedInLoopTests_PropertyAssignment()
+    public async Task StringConcatenatedInLoop_PropertyAssignment()
     {
         var original = @"
 Test res = null;
@@ -190,7 +190,7 @@ class Test
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_AssignmentAndConcatenationSeparated()
+    public async Task StringConcatenatedInLoop_AssignmentAndConcatenationSeparated()
     {
         var original = @"
 var res = string.Empty;
@@ -204,7 +204,7 @@ while (true)
     }
 
     [TestMethod]
-    public async Task StringConcatenatedInLoopTests_AssignmentAndConcatenationSeparated_Multiple()
+    public async Task StringConcatenatedInLoop_AssignmentAndConcatenationSeparated_Multiple()
     {
         var original = @"
 var res = string.Empty;
@@ -218,7 +218,7 @@ while (true)
     }
 
     [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/292")]
-    public async Task StringConcatenatedInLoopTests_AssignmentInWhileCondition()
+    public async Task StringConcatenatedInLoop_AssignmentInWhileCondition()
     {
         var original = @"
 using System;
@@ -231,6 +231,26 @@ using (StreamReader reader = File.OpenText(""file.txt""))
     {
         Console.Write(line);
     }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/308")]
+    public async Task StringConcatenatedInLoop_ConcatenationInsideObjectCreation()
+    {
+        var original = @"
+for(var i = 0; i < 10; i++)
+{
+    System.Console.WriteLine(new Test
+    {
+        SomeProp = ""file_"" + i
+    });
+}
+
+class Test
+{
+    public string SomeProp { get; set; }
 }";
 
         await VerifyCS.VerifyNoDiagnostic(original);

--- a/SharpSource/SharpSource.Test/SwitchDoesNotHandleAllEnumOptionsTests.cs
+++ b/SharpSource/SharpSource.Test/SwitchDoesNotHandleAllEnumOptionsTests.cs
@@ -510,9 +510,9 @@ namespace ConsoleApplication1
                     throw new System.NotImplementedException();
                 case WriteThrough:
                     throw new System.NotImplementedException();
-                case FileOptions.Encrypted:
+                case Encrypted:
                     break;
-                case FileOptions.SequentialScan:
+                case SequentialScan:
                     break;
                 case FileOptions.RandomAccess:
                     break;

--- a/SharpSource/SharpSource.Test/UnnecessaryEnumerableMaterializationTests.cs
+++ b/SharpSource/SharpSource.Test/UnnecessaryEnumerableMaterializationTests.cs
@@ -273,4 +273,17 @@ void Method(IList<string> list)
 
         await VerifyCS.VerifyNoDiagnostic(original);
     }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/310")]
+    public async Task UnnecessaryEnumerableMaterialization_ToListForEach()
+    {
+        var original = @"
+using System.Linq;
+using System.Collections.Generic;
+
+var files = new[] { """" };
+files.OfType<string>().ToList().ForEach(x => System.Console.Write(x));";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
 }

--- a/SharpSource/SharpSource.Test/UnnecessaryEnumerableMaterializationTests.cs
+++ b/SharpSource/SharpSource.Test/UnnecessaryEnumerableMaterializationTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
+using SharpSource.Test.Helpers;
 using VerifyCS = SharpSource.Test.CSharpCodeFixVerifier<SharpSource.Diagnostics.UnnecessaryEnumerableMaterializationAnalyzer, SharpSource.Diagnostics.UnnecessaryEnumerableMaterializationCodeFix>;
 
 namespace SharpSource.Test;
@@ -254,5 +254,23 @@ IEnumerable<string> values = new [] { ""test"" };
 values!.ToList();";
 
         await VerifyCS.VerifyCodeFix(original, VerifyCS.Diagnostic().WithMessage("ToArray is unnecessarily materializing the IEnumerable and can be omitted"), expected);
+    }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/310")]
+    public async Task UnnecessaryEnumerableMaterialization_ExpressionAcceptsBaseType()
+    {
+        var original = @"
+using System.Linq;
+using System.Collections.Generic;
+
+var files = new[] { """" };
+Method(files.OfType<string>().ToList());
+
+void Method(IList<string> list)
+{
+
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
     }
 }

--- a/SharpSource/SharpSource/Diagnostics/StringConcatenatedInLoopAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/StringConcatenatedInLoopAnalyzer.cs
@@ -53,6 +53,12 @@ public class StringConcatenatedInLoopAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
+            var nestedInsideObjectCreation = assignment.Ancestors().OfType<IObjectCreationOperation>().FirstOrDefault() is not null;
+            if (nestedInsideObjectCreation)
+            {
+                return;
+            }
+
             if (assignment.Target is ILocalReferenceOperation localRef &&
                 surroundingLoop.Body is IBlockOperation body &&
                 body.Locals.Any(s => s.Equals(localRef.Local, SymbolEqualityComparer.Default)))


### PR DESCRIPTION
closes #308 
closes #309 
closes #310 

Made progress on #148 -- will test out the impact once new vsix is released