### PR TITLE
`StringConcatenatedInLoop`: Assignments without a concatenation referencing the assigned field won't trigger a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ https://keepachangelog.com/en/1.0.0/
 - `StringConcatenatedInLoop`: Assignments without a concatenation referencing the assigned field won't trigger a warning
 - `StaticInitializerAccessedBeforeInitialization`: No longer triggers if the referenced symbol is used an argument to a method call
 - `SwitchIsMissingDefaultLabel`: Restricted the IDE warning to the `switch` value instead of the entire statement
+- `EqualsAndGetHashcodeNotImplementedTogether`, `RethrowExceptionWithoutLosingStacktrace` and `StringPlaceHoldersInWrongOrder`: Minor improvements to code fixes to return individual documents instead of a solution
 
 ## [1.21.4] - 2023-01-29
 - `StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ https://keepachangelog.com/en/1.0.0/
 ## [1.21.5] - 2023-01-30
 - `StringConcatenatedInLoop`: Assignments without a concatenation referencing the assigned field won't trigger a warning
 - `StaticInitializerAccessedBeforeInitialization`: No longer triggers if the referenced symbol is used an argument to a method call
+- `SwitchIsMissingDefaultLabel`: Restricted the IDE warning to the `switch` value instead of the entire statement
 
 ## [1.21.4] - 2023-01-29
 - `StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.21.5] - 2023-01-29
+- `StringConcatenatedInLoop`: Assignments without a concatenation referencing the assigned field won't trigger a warning
+
 ## [1.21.4] - 2023-01-29
 - `StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning
 - `StringConcatenatedInLoop`: Does not trigger when assigning to the loop variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
-## [1.21.5] - 2023-01-30
+## [1.21.5] - 2023-01-31
 - `StringConcatenatedInLoop`: Assignments without a concatenation referencing the assigned field won't trigger a warning
 - `StaticInitializerAccessedBeforeInitialization`: No longer triggers if the referenced symbol is used an argument to a method call
 - `SwitchIsMissingDefaultLabel`: Restricted the IDE warning to the `switch` value instead of the entire statement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
-## [1.21.5] - 2023-01-29
+## [1.21.5] - 2023-01-30
 - `StringConcatenatedInLoop`: Assignments without a concatenation referencing the assigned field won't trigger a warning
+- `StaticInitializerAccessedBeforeInitialization`: No longer triggers if the referenced symbol is used an argument to a method call
 
 ## [1.21.4] - 2023-01-29
 - `StringConcatenatedInLoop`: Concatenations inside object creation expressions no longer trigger a warning

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.21.4" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.21.5" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/EqualsAndGetHashcodeNotImplementedTogetherCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/EqualsAndGetHashcodeNotImplementedTogetherCodeFix.cs
@@ -44,32 +44,30 @@ public class EqualsAndGetHashcodeNotImplementedTogetherCodeFix : CodeFixProvider
         }
     }
 
-    private static async Task<Solution> ImplementEqualsAsync(Document document, SyntaxNode root, SyntaxNode statement)
+    private static async Task<Document> ImplementEqualsAsync(Document document, SyntaxNode root, SyntaxNode statement)
     {
         var classDeclaration = (ClassDeclarationSyntax)statement;
 
         var newRoot = root.ReplaceNode(classDeclaration, classDeclaration.AddMembers(GetEqualsMethod()));
         var newDocument = await Simplifier.ReduceAsync(document.WithSyntaxRoot(newRoot)).ConfigureAwait(false);
-        return newDocument.Project.Solution;
+        return newDocument;
     }
 
-    private static async Task<Solution> ImplementGetHashCodeAsync(Document document, SyntaxNode root, SyntaxNode statement)
+    private static async Task<Document> ImplementGetHashCodeAsync(Document document, SyntaxNode root, SyntaxNode statement)
     {
         var classDeclaration = (ClassDeclarationSyntax)statement;
 
         var newRoot = root.ReplaceNode(classDeclaration, classDeclaration.AddMembers(GetGetHashCodeMethod()));
         var newDocument = await Simplifier.ReduceAsync(document.WithSyntaxRoot(newRoot)).ConfigureAwait(false);
-        return newDocument.Project.Solution;
+        return newDocument;
     }
 
     private static MethodDeclarationSyntax GetEqualsMethod()
     {
         var publicModifier = SyntaxFactory.Token(SyntaxKind.PublicKeyword);
         var overrideModifier = SyntaxFactory.Token(SyntaxKind.OverrideKeyword);
-        var bodyStatement = SyntaxFactory.ParseStatement("throw new System.NotImplementedException();")
-            .WithAdditionalAnnotations(Simplifier.Annotation);
-        var parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("obj"))
-            .WithType(SyntaxFactory.ParseTypeName("object"));
+        var bodyStatement = SyntaxFactory.ParseStatement("throw new System.NotImplementedException();").WithAdditionalAnnotations(Simplifier.Annotation);
+        var parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("obj")).WithType(SyntaxFactory.ParseTypeName("object"));
 
         return SyntaxFactory.MethodDeclaration(SyntaxFactory.ParseTypeName("bool"), "Equals")
                 .AddModifiers(publicModifier, overrideModifier)
@@ -82,8 +80,7 @@ public class EqualsAndGetHashcodeNotImplementedTogetherCodeFix : CodeFixProvider
     {
         var publicModifier = SyntaxFactory.Token(SyntaxKind.PublicKeyword);
         var overrideModifier = SyntaxFactory.Token(SyntaxKind.OverrideKeyword);
-        var bodyStatement = SyntaxFactory.ParseStatement("throw new System.NotImplementedException();")
-            .WithAdditionalAnnotations(Simplifier.Annotation);
+        var bodyStatement = SyntaxFactory.ParseStatement("throw new System.NotImplementedException();").WithAdditionalAnnotations(Simplifier.Annotation);
 
         return SyntaxFactory.MethodDeclaration(SyntaxFactory.ParseTypeName("int"), "GetHashCode")
                 .AddModifiers(publicModifier, overrideModifier)

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/RethrowExceptionWithoutLosingStacktraceCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/RethrowExceptionWithoutLosingStacktraceCodeFix.cs
@@ -33,12 +33,11 @@ public class RethrowExceptionWithoutLosingStacktraceCodeFix : CodeFixProvider
                 RethrowExceptionWithoutLosingStacktraceAnalyzer.Rule.Id), diagnostic);
     }
 
-    private static Task<Solution> RemoveRethrowAsync(Document document, SyntaxNode root,
-                                              ThrowStatementSyntax throwStatement)
+    private static Task<Document> RemoveRethrowAsync(Document document, SyntaxNode root, ThrowStatementSyntax throwStatement)
     {
         var newStatement = SyntaxFactory.ThrowStatement();
         var newRoot = root.ReplaceNode(throwStatement, newStatement);
         var newDocument = document.WithSyntaxRoot(newRoot);
-        return Task.FromResult(newDocument.Project.Solution);
+        return Task.FromResult(newDocument);
     }
 }

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/StringPlaceholdersInWrongOrderCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/StringPlaceholdersInWrongOrderCodeFix.cs
@@ -17,8 +17,7 @@ namespace SharpSource.Diagnostics;
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class StringPlaceHoldersInWrongOrderCodeFix : CodeFixProvider
 {
-    public override ImmutableArray<string> FixableDiagnosticIds
-        => ImmutableArray.Create(StringPlaceholdersInWrongOrderAnalyzer.Rule.Id);
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(StringPlaceholdersInWrongOrderAnalyzer.Rule.Id);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -45,7 +44,7 @@ public class StringPlaceHoldersInWrongOrderCodeFix : CodeFixProvider
             diagnostic);
     }
 
-    private static Task<Solution> ReOrderPlaceholdersAsync(Document document, SyntaxNode root,
+    private static Task<Document> ReOrderPlaceholdersAsync(Document document, SyntaxNode root,
                                                            InvocationExpressionSyntax stringFormatInvocation)
     {
         var firstArgumentIsLiteral = stringFormatInvocation.ArgumentList.Arguments[0].Expression is LiteralExpressionSyntax;
@@ -139,7 +138,7 @@ public class StringPlaceHoldersInWrongOrderCodeFix : CodeFixProvider
         var newInvocation = stringFormatInvocation.WithArgumentList(newArguments);
         var newRoot = root.ReplaceNode(stringFormatInvocation, newInvocation);
         var newDocument = document.WithSyntaxRoot(newRoot);
-        return Task.FromResult(newDocument.Project.Solution);
+        return Task.FromResult(newDocument);
     }
 
     /// <summary>

--- a/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchIsMissingDefaultLabelCodeFix.cs
+++ b/SharpSource/SharpSource.CodeFixes/Diagnostics/SwitchIsMissingDefaultLabelCodeFix.cs
@@ -9,16 +9,15 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
-
 using SharpSource.Utilities;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace SharpSource.Diagnostics;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class SwitchIsMissingDefaultLabelCodeFix : CodeFixProvider
 {
-    public override ImmutableArray<string> FixableDiagnosticIds
-        => ImmutableArray.Create(SwitchIsMissingDefaultLabelAnalyzer.Rule.Id);
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SwitchIsMissingDefaultLabelAnalyzer.Rule.Id);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -29,7 +28,7 @@ public class SwitchIsMissingDefaultLabelCodeFix : CodeFixProvider
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
         var switchToken = root.FindNode(diagnosticSpan);
-        var statement = switchToken?.DescendantNodesAndSelf().FirstOfKind<SwitchStatementSyntax>(SyntaxKind.SwitchStatement);
+        var statement = switchToken?.AncestorsAndSelf().FirstOfKind<SwitchStatementSyntax>(SyntaxKind.SwitchStatement);
         if (root is not CompilationUnitSyntax compilation || statement == default)
         {
             return;
@@ -43,11 +42,9 @@ public class SwitchIsMissingDefaultLabelCodeFix : CodeFixProvider
 
     private static Task<Document> AddDefaultCaseAsync(Document document, CompilationUnitSyntax root, SwitchStatementSyntax switchBlock)
     {
-        var argumentException =
-            SyntaxFactory.ThrowStatement(SyntaxFactory.ParseExpression($"new ArgumentException(\"Unsupported value\")"))
-                         .WithAdditionalAnnotations(Formatter.Annotation);
-        var statements = SyntaxFactory.List(new List<StatementSyntax> { argumentException });
-        var defaultCase = SyntaxFactory.SwitchSection(SyntaxFactory.List<SwitchLabelSyntax>(new[] { SyntaxFactory.DefaultSwitchLabel() }), statements);
+        var argumentException = ThrowStatement(ParseExpression($"new ArgumentException(\"Unsupported value\")")).WithAdditionalAnnotations(Formatter.Annotation);
+        var statements = List(new List<StatementSyntax> { argumentException });
+        var defaultCase = SwitchSection(List<SwitchLabelSyntax>(new[] { DefaultSwitchLabel() }), statements);
 
         var newNode = switchBlock.AddSections(defaultCase.WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation, Simplifier.AddImportsAnnotation, SymbolAnnotation.Create("System.ArgumentException")));
         var newRoot = root.ReplaceNode(switchBlock, newNode);

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.21.4</PackageVersion>
+    <PackageVersion>1.21.5</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/ComparingStringsWithoutStringComparisonTests.cs
+++ b/SharpSource/SharpSource.Test/ComparingStringsWithoutStringComparisonTests.cs
@@ -95,13 +95,15 @@ using System;
 
 string s1 = string.Empty;
 string s2 = string.Empty;
-bool result = {{|#0:s1?.{call}().Trim()|}} == s2?.{call}().Trim();";
+
+bool result = {{|#0:s1?.Trim()?.{call}()|}} == s2?.Trim()?.{call}();";
 
         var result = @$"
 using System;
 
 string s1 = string.Empty;
 string s2 = string.Empty;
+
 bool result = string.Equals(s1?.Trim(), s2?.Trim(), StringComparison.{expectedStringComparison});";
 
         await VerifyCS.VerifyCodeFix(original, VerifyCS.Diagnostic().WithMessage("A string is being compared through allocating a new string. Use a case-insensitive comparison instead."), result);

--- a/SharpSource/SharpSource.Test/StaticInitializerAccessedBeforeInitializationTests.cs
+++ b/SharpSource/SharpSource.Test/StaticInitializerAccessedBeforeInitializationTests.cs
@@ -351,18 +351,18 @@ class Test
         await VerifyCS.VerifyNoDiagnostic(original);
     }
 
-    [TestMethod]
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/314")]
     public async Task StaticInitializerAccessedBeforeInitialization_AsArgumentToMethodInvocation()
     {
         var original = @"
 class Test
 {
-	static string FirstField = SomeFunction({|#0:SomeArg|});
+	static string FirstField = SomeFunction(SomeArg);
 	static string SomeFunction(string arg) => arg;
 	static string SomeArg = ""test"";
 }";
 
-        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("FirstField accesses SomeArg but both are marked as static and SomeArg will not be initialized when it is used"));
+        await VerifyCS.VerifyNoDiagnostic(original);
     }
 
     [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/173")]

--- a/SharpSource/SharpSource.Test/StringConcatenatedInLoopTests.cs
+++ b/SharpSource/SharpSource.Test/StringConcatenatedInLoopTests.cs
@@ -320,4 +320,18 @@ class TestTwo
 
         await VerifyCS.VerifyNoDiagnostic(original);
     }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/312")]
+    public async Task StringConcatenatedInLoop_ConcatenationWithoutReferencingTarget()
+    {
+        var original = @"
+string s = string.Empty;
+
+while (true)
+{
+    s = ""test"" + "".txt"";
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
 }

--- a/SharpSource/SharpSource.Test/SwitchIsMissingDefaultLabelTests.cs
+++ b/SharpSource/SharpSource.Test/SwitchIsMissingDefaultLabelTests.cs
@@ -30,12 +30,12 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum.Fizz;
-            {|#0:switch (e)
+            switch ({|#0:e|})
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
                     break;
-            }|}
+            }
         }
     }
 }";
@@ -55,14 +55,14 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum.Fizz;
-            {|#0:switch (e)
+            switch ({|#0:e|})
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
                     break;
                 default:
                     throw new ArgumentException(""Unsupported value"");
-            }|}
+            }
         }
     }
 }";
@@ -83,12 +83,12 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = ""test"";
-            {|#0:switch (e)
+            switch ({|#0:e|})
             {
                 case ""test"":
                 case ""test1"":
                     break;
-            }|}
+            }
         }
     }
 }";
@@ -130,12 +130,12 @@ namespace ConsoleApplication1
     {
         void Method()
         {
-            {|#0:switch (""test"")
+            switch ({|#0:""test""|})
             {
                 case ""test"":
                 case ""test1"":
                     break;
-            }|}
+            }
         }
     }
 }";
@@ -176,12 +176,12 @@ namespace ConsoleApplication1
     {
         void Method()
         {
-            {|#0:switch (0)
+            switch ({|#0:0|})
             {
                 case 0:
                 case 1:
                     break;
-            }|}
+            }
         }
     }
 }";
@@ -250,12 +250,12 @@ namespace ConsoleApplication1
         void Method()
         {
             var x = 5;
-            {|#0:switch ((x))
+            switch (({|#0:x|}))
             {
                 case 5:
                 case 6:
                     break;
-            }|}
+            }
         }
     }
 }";
@@ -297,12 +297,12 @@ namespace ConsoleApplication1
     {
         void Method()
         {
-            {|#0:switch ((""test""))
+            switch (({|#0:""test""|}))
             {
                 case ""test"":
                 case ""test1"":
                     break;
-            }|}
+            }
         }
     }
 }";
@@ -343,12 +343,12 @@ namespace ConsoleApplication1
     {
         void Method()
         {
-            {|#0:switch ((0))
+            switch (({|#0:0|}))
             {
                 case 0:
                 case 1:
                     break;
-            }|}
+            }
         }
     }
 }";
@@ -387,12 +387,12 @@ namespace ConsoleApplication1
     {
         void Method()
         {
-            {|#0:switch (0)
+            switch ({|#0:0|})
             {
                 case 0:
                 case 1:
                     break;
-            }|}
+            }
         }
     }
 }";
@@ -427,10 +427,10 @@ namespace ConsoleApplication1
         var original = @"
 using System;
 
-{|#0:switch (Test.A)
+switch ({|#0:Test.A|})
 {
     case Test.A: return;
-}|}
+}
 
 enum Test { A, B }";
 

--- a/SharpSource/SharpSource/Diagnostics/AsyncMethodWithVoidReturnTypeAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/AsyncMethodWithVoidReturnTypeAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;

--- a/SharpSource/SharpSource/Diagnostics/StaticInitializerAccessedBeforeInitializationAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/StaticInitializerAccessedBeforeInitializationAnalyzer.cs
@@ -62,7 +62,7 @@ public sealed class StaticInitializerAccessedBeforeInitializationAnalyzer : Diag
                     var operation = context.Operation.Parent;
                     while (operation is not null)
                     {
-                        if (operation.Kind is OperationKind.AnonymousFunction or OperationKind.NameOf)
+                        if (operation.Kind is OperationKind.AnonymousFunction or OperationKind.NameOf or OperationKind.Invocation)
                         {
                             return;
                         }

--- a/SharpSource/SharpSource/Diagnostics/StringConcatenatedInLoopAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/StringConcatenatedInLoopAnalyzer.cs
@@ -61,7 +61,7 @@ public class StringConcatenatedInLoopAnalyzer : DiagnosticAnalyzer
             }
 
             if (surroundingLoop.Body is IBlockOperation body)
-            {                
+            {
                 var isReferencingLocal = surroundingLoop.Locals.Concat(body.Locals).Any(s => s.Equals(assignedSymbol, SymbolEqualityComparer.Default));
                 if (isReferencingLocal)
                 {

--- a/SharpSource/SharpSource/Diagnostics/StringConcatenatedInLoopAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/StringConcatenatedInLoopAnalyzer.cs
@@ -29,11 +29,12 @@ public class StringConcatenatedInLoopAnalyzer : DiagnosticAnalyzer
         context.RegisterOperationAction(context =>
         {
             var assignment = (IAssignmentOperation)context.Operation;
+            var assignedSymbol = GetSymbol(assignment.Target);
 
             var isEligible = assignment switch
             {
                 ICompoundAssignmentOperation { OperatorKind: BinaryOperatorKind.Add } => true,
-                ISimpleAssignmentOperation { Value: IBinaryOperation { OperatorKind: BinaryOperatorKind.Add } } => true,
+                ISimpleAssignmentOperation { Value: IBinaryOperation { OperatorKind: BinaryOperatorKind.Add } binary } => BinaryOperationConcatenatesSymbol(binary, assignedSymbol),
                 _ => false
             };
 
@@ -60,9 +61,8 @@ public class StringConcatenatedInLoopAnalyzer : DiagnosticAnalyzer
             }
 
             if (surroundingLoop.Body is IBlockOperation body)
-            {
-                var instanceToFind = GetLocal(assignment.Target);
-                var isReferencingLocal = surroundingLoop.Locals.Concat(body.Locals).Any(s => s.Equals(instanceToFind, SymbolEqualityComparer.Default));
+            {                
+                var isReferencingLocal = surroundingLoop.Locals.Concat(body.Locals).Any(s => s.Equals(assignedSymbol, SymbolEqualityComparer.Default));
                 if (isReferencingLocal)
                 {
                     return;
@@ -73,11 +73,32 @@ public class StringConcatenatedInLoopAnalyzer : DiagnosticAnalyzer
         }, OperationKind.CompoundAssignment, OperationKind.SimpleAssignment);
     }
 
-    private static ISymbol? GetLocal(IOperation? operation) => operation switch
+    private static ISymbol? GetSymbol(IOperation? operation) => operation switch
     {
         ILocalReferenceOperation localRef => localRef.Local,
-        IPropertyReferenceOperation propRef => GetLocal(propRef.Instance),
-        IFieldReferenceOperation fieldRef => GetLocal(fieldRef.Instance),
+        IPropertyReferenceOperation propRef => GetSymbol(propRef.Instance),
+        IFieldReferenceOperation fieldRef => GetSymbol(fieldRef.Instance),
         _ => default
     };
+
+    private static bool BinaryOperationConcatenatesSymbol(IBinaryOperation binary, ISymbol? targetSymbol)
+    {
+        if (targetSymbol is null)
+        {
+            return false;
+        }
+
+        static bool traverse(IOperation op, ISymbol targetSymbol)
+        {
+            if (op is IBinaryOperation nestedBinaryOp)
+            {
+                return traverse(nestedBinaryOp.LeftOperand, targetSymbol) || traverse(nestedBinaryOp.RightOperand, targetSymbol);
+            }
+
+            var symbol = GetSymbol(op);
+            return SymbolEqualityComparer.Default.Equals(symbol, targetSymbol);
+        }
+
+        return traverse(binary, targetSymbol);
+    }
 }

--- a/SharpSource/SharpSource/Diagnostics/SwitchIsMissingDefaultLabelAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/SwitchIsMissingDefaultLabelAnalyzer.cs
@@ -31,7 +31,7 @@ public class SwitchIsMissingDefaultLabelAnalyzer : DiagnosticAnalyzer
 
             if (!surroundingSwitch.Cases.SelectMany(c => c.Clauses).OfType<IDefaultCaseClauseOperation>().Any())
             {
-                context.ReportDiagnostic(Diagnostic.Create(Rule, surroundingSwitch.Syntax.GetLocation()));
+                context.ReportDiagnostic(Diagnostic.Create(Rule, surroundingSwitch.Value.Syntax.GetLocation()));
             }
         }, OperationKind.Switch);
     }


### PR DESCRIPTION
closes #312 
closes #314 
closes #313 