### PR TITLE
`StringConcatenatedInLoop`: No longer triggers if concatenation is immediately followed by a `return` or `break` clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ https://keepachangelog.com/en/1.0.0/
 - `StringConcatenatedInLoop`: No longer triggers if concatenation is immediately followed by a `return` or `break` clause
 - `AsyncOverloadsAvailable`: Doesn't trigger inside a synchronous local function
 - `SynchronousTaskWait`: Now also supports anonymous functions
+- `ThreadSleepInAsyncMethod`: Now also supports anonymous functions
 
 ## [1.21.6] - 2023-02-10
 - `StructWithoutElementaryMethodsOverridden`: Generates an `Equals(object? o)` method when nullable reference types are enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
-## [1.22.0] - 2023-02-19
+## [1.22.0] - 2023-02-20
 - `StringConcatenatedInLoop`: No longer triggers if concatenation is immediately followed by a `return` or `break` clause
+- `AsyncOverloadsAvailable`: Doesn't trigger inside a synchronous local function
 
 ## [1.21.6] - 2023-02-10
 - `StructWithoutElementaryMethodsOverridden`: Generates an `Equals(object? o)` method when nullable reference types are enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ https://keepachangelog.com/en/1.0.0/
 ## [1.22.0] - 2023-02-20
 - `StringConcatenatedInLoop`: No longer triggers if concatenation is immediately followed by a `return` or `break` clause
 - `AsyncOverloadsAvailable`: Doesn't trigger inside a synchronous local function
+- `SynchronousTaskWait`: Now also supports anonymous functions
 
 ## [1.21.6] - 2023-02-10
 - `StructWithoutElementaryMethodsOverridden`: Generates an `Equals(object? o)` method when nullable reference types are enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.22.0] - 2023-02-19
+- `StringConcatenatedInLoop`: No longer triggers if concatenation is immediately followed by a `return` or `break` clause
+
 ## [1.21.6] - 2023-02-10
 - `StructWithoutElementaryMethodsOverridden`: Generates an `Equals(object? o)` method when nullable reference types are enabled
 - `EqualsAndGetHashcodeNotImplementedTogether`: Generates an `Equals(object? o)` method when nullable reference types are enabled

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.21.6" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.22.0" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.21.6</PackageVersion>
+    <PackageVersion>1.22.0</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/StringConcatenatedInLoopTests.cs
+++ b/SharpSource/SharpSource.Test/StringConcatenatedInLoopTests.cs
@@ -334,4 +334,34 @@ while (true)
 
         await VerifyCS.VerifyNoDiagnostic(original);
     }
+
+    [TestMethod]
+    public async Task StringConcatenatedInLoop_Return()
+    {
+        var original = @"
+var res = string.Empty;
+while (true)
+{
+    {|#0:res += ""test""|};
+    return;
+}
+";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task StringConcatenatedInLoop_Break()
+    {
+        var original = @"
+var res = string.Empty;
+while (true)
+{
+    {|#0:res += ""test""|};
+    break;
+}
+";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
 }

--- a/SharpSource/SharpSource.Test/SynchronousTaskWaitTests.cs
+++ b/SharpSource/SharpSource.Test/SynchronousTaskWaitTests.cs
@@ -168,7 +168,6 @@ async Task MyMethod() {
     }
 
     [TestMethod]
-    [Ignore("See https://github.com/Vannevelj/SharpSource/issues/268")]
     public async Task SynchronousTaskWait_AsyncLambda_AsAnonymousFunction()
     {
         var original = @"

--- a/SharpSource/SharpSource.Test/ThreadSleepInAsyncMethodTests.cs
+++ b/SharpSource/SharpSource.Test/ThreadSleepInAsyncMethodTests.cs
@@ -559,7 +559,6 @@ class MyClass
     }
 
     [TestMethod]
-    [Ignore("See https://github.com/Vannevelj/SharpSource/issues/268")]
     public async Task ThreadSleepInAsyncMethod_AsyncLambda_AsAnonymousFunction()
     {
         var original = @"

--- a/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/AsyncOverloadsAvailableAnalyzer.cs
@@ -36,15 +36,7 @@ public class AsyncOverloadsAvailableAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol? cancellationTokenSymbol)
     {
-        var surroundingMethodOperation = context.Operation.Ancestors().FirstOrDefault(a => a is ILocalFunctionOperation or IMethodBodyBaseOperation or IAnonymousFunctionOperation);
-        var surroundingMethod = surroundingMethodOperation switch
-        {
-            ILocalFunctionOperation localFunction => localFunction.Symbol,
-            IMethodBodyBaseOperation methodBody => methodBody.SemanticModel?.GetDeclaredSymbol(methodBody.Syntax) as IMethodSymbol,
-            IAnonymousFunctionOperation anonFunction => anonFunction.Symbol,
-            _ => default,
-        };
-
+        var surroundingMethod = context.Operation.GetSurroundingMethodContext();
         if (surroundingMethod is null)
         {
             return;

--- a/SharpSource/SharpSource/Diagnostics/SynchronousTaskWaitAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/SynchronousTaskWaitAnalyzer.cs
@@ -36,15 +36,7 @@ public class SynchronousTaskWaitAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(OperationAnalysisContext context, IInvocationOperation invocation, IMethodSymbol[]? taskWaitSymbols)
     {
-        var surroundingMethodOperation = context.Operation.Ancestors().FirstOrDefault(a => a is ILocalFunctionOperation or IMethodBodyBaseOperation or IAnonymousFunctionOperation);
-        var surroundingMethod = surroundingMethodOperation switch
-        {
-            ILocalFunctionOperation localFunction => localFunction.Symbol,
-            IMethodBodyBaseOperation methodBody => methodBody.SemanticModel?.GetDeclaredSymbol(methodBody.Syntax) as IMethodSymbol,
-            IAnonymousFunctionOperation anonFunction => anonFunction.Symbol,
-            _ => default,
-        };
-
+        var surroundingMethod = context.Operation.GetSurroundingMethodContext();
         if (surroundingMethod is null)
         {
             return;

--- a/SharpSource/SharpSource/Diagnostics/ThreadSleepInAsyncMethodAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/ThreadSleepInAsyncMethodAnalyzer.cs
@@ -29,20 +29,32 @@ public class ThreadSleepInAsyncMethodAnalyzer : DiagnosticAnalyzer
         {
             var threadSleepSymbols = context.Compilation.GetTypeByMetadataName("System.Threading.Thread")?.GetMembers("Sleep").OfType<IMethodSymbol>().ToArray();
 
-            context.RegisterSymbolStartAction(symbolContext =>
-            {
-                var method = (IMethodSymbol)symbolContext.Symbol;
-                var isAsync = method.IsAsync || method.Name == WellKnownMemberNames.TopLevelStatementsEntryPointMethodName;
-                if (isAsync || method.ReturnType.IsTaskType())
-                {
-                    symbolContext.RegisterOperationAction(context => Analyze(context, (IInvocationOperation)context.Operation, threadSleepSymbols, isAsync), OperationKind.Invocation);
-                }
-            }, SymbolKind.Method);
+            context.RegisterOperationAction(context => Analyze(context, (IInvocationOperation)context.Operation, threadSleepSymbols), OperationKind.Invocation);
         });
     }
 
-    private static void Analyze(OperationAnalysisContext context, IInvocationOperation invocation, IMethodSymbol[]? threadSleepSymbols, bool isAsync)
+    private static void Analyze(OperationAnalysisContext context, IInvocationOperation invocation, IMethodSymbol[]? threadSleepSymbols)
     {
+        var surroundingMethodOperation = context.Operation.Ancestors().FirstOrDefault(a => a is ILocalFunctionOperation or IMethodBodyBaseOperation or IAnonymousFunctionOperation);
+        var surroundingMethod = surroundingMethodOperation switch
+        {
+            ILocalFunctionOperation localFunction => localFunction.Symbol,
+            IMethodBodyBaseOperation methodBody => methodBody.SemanticModel?.GetDeclaredSymbol(methodBody.Syntax) as IMethodSymbol,
+            IAnonymousFunctionOperation anonFunction => anonFunction.Symbol,
+            _ => default,
+        };
+
+        if (surroundingMethod is null)
+        {
+            return;
+        }
+
+        var isAsync = surroundingMethod.IsAsync || surroundingMethod.Name == WellKnownMemberNames.TopLevelStatementsEntryPointMethodName;
+        if (!isAsync && !surroundingMethod.ReturnType.IsTaskType())
+        {
+            return;
+        }
+
         if (!threadSleepSymbols.Any(symbol => invocation.TargetMethod.Equals(symbol, SymbolEqualityComparer.Default)))
         {
             return;

--- a/SharpSource/SharpSource/Diagnostics/ThreadSleepInAsyncMethodAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/ThreadSleepInAsyncMethodAnalyzer.cs
@@ -35,15 +35,7 @@ public class ThreadSleepInAsyncMethodAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(OperationAnalysisContext context, IInvocationOperation invocation, IMethodSymbol[]? threadSleepSymbols)
     {
-        var surroundingMethodOperation = context.Operation.Ancestors().FirstOrDefault(a => a is ILocalFunctionOperation or IMethodBodyBaseOperation or IAnonymousFunctionOperation);
-        var surroundingMethod = surroundingMethodOperation switch
-        {
-            ILocalFunctionOperation localFunction => localFunction.Symbol,
-            IMethodBodyBaseOperation methodBody => methodBody.SemanticModel?.GetDeclaredSymbol(methodBody.Syntax) as IMethodSymbol,
-            IAnonymousFunctionOperation anonFunction => anonFunction.Symbol,
-            _ => default,
-        };
-
+        var surroundingMethod = context.Operation.GetSurroundingMethodContext();
         if (surroundingMethod is null)
         {
             return;

--- a/SharpSource/SharpSource/Utilities/Extensions.cs
+++ b/SharpSource/SharpSource/Utilities/Extensions.cs
@@ -220,4 +220,18 @@ public static class Extensions
 
         return default;
     }
+
+    public static IMethodSymbol? GetSurroundingMethodContext(this IOperation operation)
+    {
+        var surroundingMethodOperation = operation.Ancestors().FirstOrDefault(a => a is ILocalFunctionOperation or IMethodBodyBaseOperation or IAnonymousFunctionOperation);
+        var surroundingMethod = surroundingMethodOperation switch
+        {
+            ILocalFunctionOperation localFunction => localFunction.Symbol,
+            IMethodBodyBaseOperation methodBody => methodBody.SemanticModel?.GetDeclaredSymbol(methodBody.Syntax) as IMethodSymbol,
+            IAnonymousFunctionOperation anonFunction => anonFunction.Symbol,
+            _ => default,
+        };
+
+        return surroundingMethod;
+    }
 }


### PR DESCRIPTION
closes #291 
closes #321 
closes #268 