### PR TITLE
`GetHashCodeRefersToMutableMember`: No longer triggers on `init` property setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.23.3] - 2023-05-15
+- `GetHashCodeRefersToMutableMember`: No longer triggers on `init` property setters
+
 ## [1.23.2] - 2023-03-18
 - `AsyncOverloadsAvailable`: Will no longer pass through the `CancellationToken` if it's inside a static local function
 - `AsyncOverloadsAvailable`: Will correctly identify overloads if the synchronous variant returns a `Task`-like type

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.23.2" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.23.3" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.23.2</PackageVersion>
+    <PackageVersion>1.23.3</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/GetHashCodeRefersToMutableMemberTests.cs
+++ b/SharpSource/SharpSource.Test/GetHashCodeRefersToMutableMemberTests.cs
@@ -419,4 +419,21 @@ partial class ClassX
 
         await VerifyCS.VerifyAnalyzerAsync(file1, additionalFiles: new[] { file2 }, VerifyCS.Diagnostic(GetHashCodeRefersToMutableMemberAnalyzer.PropertyRule).WithMessage("GetHashCode() refers to mutable property Code"));
     }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/339")]
+    public async Task GetHashCodeRefersToMutableMember_InitProperty()
+    {
+        var original = @"
+public class Foo
+{
+    public string Boo { get; init; }
+
+    public override int GetHashCode()
+    {
+        return Boo.GetHashCode();
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
 }

--- a/SharpSource/SharpSource/Diagnostics/GetHashCodeRefersToMutableMemberAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/GetHashCodeRefersToMutableMemberAnalyzer.cs
@@ -102,5 +102,5 @@ public class GetHashCodeRefersToMutableMemberAnalyzer : DiagnosticAnalyzer
         return true;
     }
 
-    private static bool PropertyIsMutable(IPropertySymbol property) => property.SetMethod != null;
+    private static bool PropertyIsMutable(IPropertySymbol property) => property is { SetMethod.IsInitOnly: false };
 }


### PR DESCRIPTION
closes #339 