### PR TITLE
`UnnecessaryEnumerableMaterialization`: If the instance is of type `IQueryable` then the analyzer will no longer trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.23.4] - 2024-01-04
+- `UnnecessaryEnumerableMaterialization`: If the instance is of type `IQueryable` then the analyzer will no longer trigger
+
 ## [1.23.3] - 2023-05-15
 - `GetHashCodeRefersToMutableMember`: No longer triggers on `init` property setters
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,28 @@
+
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.4.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+  
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.23.3" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.23.4" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.CodeFixes/SharpSource.CodeFixes.csproj
+++ b/SharpSource/SharpSource.CodeFixes/SharpSource.CodeFixes.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.23.3</PackageVersion>
+    <PackageVersion>1.23.4</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/SharpSource.Test.csproj
+++ b/SharpSource/SharpSource.Test/SharpSource.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SharpSource/SharpSource.Test/SharpSource.Test.csproj
+++ b/SharpSource/SharpSource.Test/SharpSource.Test.csproj
@@ -5,23 +5,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
   </ItemGroup>
 
   <!-- For unit testing purposes -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpSource/SharpSource.Test/UnboundedStackallocTests.cs
+++ b/SharpSource/SharpSource.Test/UnboundedStackallocTests.cs
@@ -255,4 +255,31 @@ unsafe
 
         await VerifyCS.VerifyNoDiagnostic(original);
     }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/345")]
+    public async Task UnboundedStackalloc_ConstPassedAsArgument()
+    {
+        var original = @"
+using System;
+
+const int StackBufferSize = 256;
+using var converter = new ValueUtf8Converter(stackalloc byte{|#0:[StackBufferSize]|});
+
+internal ref struct ValueUtf8Converter
+{
+    private Span<byte> _bytes;
+
+    public ValueUtf8Converter(Span<byte> initialBuffer)
+    {
+        _bytes = initialBuffer;
+    }
+
+    public void Dispose()
+    {
+        
+    }
+}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
 }

--- a/SharpSource/SharpSource.Test/UnnecessaryEnumerableMaterializationTests.cs
+++ b/SharpSource/SharpSource.Test/UnnecessaryEnumerableMaterializationTests.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharpSource.Test.Helpers;
@@ -283,6 +286,31 @@ using System.Collections.Generic;
 
 var files = new[] { """" };
 files.OfType<string>().ToList().ForEach(x => System.Console.Write(x));";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/342")]
+    public async Task UnnecessaryEnumerableMaterialization_IQueryable()
+    {
+        var original = @"
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Collections;
+using System.Collections.Generic;
+
+CustomCollection dingy = new();
+dingy.ToList().Where(x => true);
+
+public class CustomCollection : IEnumerable<int>, IQueryable<int>
+{
+    public Type ElementType => null;
+    public Expression Expression => null;
+    public IQueryProvider Provider => null;
+    public IEnumerator<int> GetEnumerator() => throw new NotImplementedException();
+    IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+}";
 
         await VerifyCS.VerifyNoDiagnostic(original);
     }

--- a/SharpSource/SharpSource.Vsix/SharpSource.Vsix.csproj
+++ b/SharpSource/SharpSource.Vsix/SharpSource.Vsix.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/SharpSource/SharpSource/SharpSource.csproj
+++ b/SharpSource/SharpSource/SharpSource.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
closes #345 -- cannot reproduce
closes #342 