### PR TITLE
Fix bug where enums with underlying types would cause a crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
@@ -27,7 +27,7 @@ jobs:
           DeployExtension: False
 
       - name: Collect artifacts - VSIX
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sharpsource.vsix
           path: SharpSource\SharpSource.Vsix\bin\Release\net472\SharpSource.vsix
@@ -35,7 +35,7 @@ jobs:
           retention-days: 5
 
       - name: Collect artifacts - nugets
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sharpsource.nupkg
           path: '**/SharpSource*.nupkg'

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Restore NuGet Packages
         run: dotnet restore sharpsource.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get version from CHANGELOG.md
       id: changelog_reader
       uses: mindsers/changelog-reader-action@v2
@@ -31,35 +31,35 @@ jobs:
       env:
         DeployExtension: False
     - name: Collect artifacts - Changelog
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: CHANGELOG.md
         path: ./CHANGELOG.md
         retention-days: 30
         if-no-files-found: error
     - name: Collect artifacts - README
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: README.md
         path: ./README.md
         retention-days: 30
         if-no-files-found: error
     - name: Collect artifacts - VSIX
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: sharpsource.vsix
         path: SharpSource\SharpSource.Vsix\bin\Release\net472\SharpSource.vsix
         if-no-files-found: error
         retention-days: 30
     - name: Collect artifacts - publishmanifest
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: publishManifest.json
         path: SharpSource\SharpSource.Vsix\publishManifest.json
         if-no-files-found: error
         retention-days: 30
     - name: Collect artifacts - nugets
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: sharpsource.nupkg
         path: '**/SharpSource*.nupkg'
@@ -71,15 +71,15 @@ jobs:
     needs: pack
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: sharpsource.nupkg
         path: .
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: sharpsource.vsix
         path: .
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: CHANGELOG.md
         path: .
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download a single artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: sharpsource.nupkg
     - name: Push to NuGet
@@ -130,7 +130,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Download a single artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: sharpsource.nupkg
     - name: Push to Github
@@ -146,15 +146,15 @@ jobs:
     needs: pack
     runs-on: windows-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: sharpsource.vsix
         path: .
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: publishManifest.json
         path: .
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: README.md
         path: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Restore NuGet Packages
         run: dotnet restore sharpsource.sln

--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v2
         id: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.24.1] - 2024-09-10
+- `EnumWithoutDefaultValue`: No longer crashes when using an enum that is not `int`, courtesy of @Genbox
+
 ## [1.24.0] - 2024-02-20
 - All analysers will no longer report diagnostics in generated code
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.24.0" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.24.1" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.24.0</PackageVersion>
+    <PackageVersion>1.24.1</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/EnumWithoutDefaultValueTests.cs
+++ b/SharpSource/SharpSource.Test/EnumWithoutDefaultValueTests.cs
@@ -89,6 +89,19 @@ enum Test {{
     [TestMethod]
     [DataRow("None")]
     [DataRow("Unknown")]
+    public async Task EnumWithoutDefaultValue_RightName_NegativeValue(string memberName)
+    {
+        var original = $@"
+enum [|Test|] : short {{
+    {memberName} = -1
+}}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    [DataRow("None")]
+    [DataRow("Unknown")]
     public async Task EnumWithoutDefaultValue_RightName_WithDifferentType(string memberName)
     {
         var original = $@"

--- a/SharpSource/SharpSource.Test/EnumWithoutDefaultValueTests.cs
+++ b/SharpSource/SharpSource.Test/EnumWithoutDefaultValueTests.cs
@@ -85,4 +85,18 @@ enum Test {{
 
         await VerifyCS.VerifyNoDiagnostic(original);
     }
+
+    [TestMethod]
+    [DataRow("None")]
+    [DataRow("Unknown")]
+    public async Task EnumWithoutDefaultValue_RightName_WithDifferentType(string memberName)
+    {
+        var original = $@"
+enum Test : ushort {{
+   {memberName} = 0,
+
+}}";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
 }

--- a/SharpSource/SharpSource.Test/EnumWithoutDefaultValueTests.cs
+++ b/SharpSource/SharpSource.Test/EnumWithoutDefaultValueTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -100,16 +101,28 @@ enum [|Test|] : short {{
     }
 
     [TestMethod]
-    [DataRow("None")]
-    [DataRow("Unknown")]
-    public async Task EnumWithoutDefaultValue_RightName_WithDifferentType(string memberName)
+    [DynamicData(nameof(GetEnumTypes), DynamicDataSourceType.Method)]
+    public async Task EnumWithoutDefaultValue_RightName_WithDifferentType(string memberName, string dataType)
     {
         var original = $@"
-enum Test : ushort {{
-   {memberName} = 0,
-
+enum Test : {dataType} {{
+   {memberName} = 0
 }}";
 
         await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    public static IEnumerable<object[]> GetEnumTypes()
+    {
+        var memberNames = new[] { "None", "Unknown" };
+        var dataTypes = new[] { "byte", "sbyte", "short", "ushort", "int", "uint", "long", "ulong" };
+
+        foreach (var memberName in memberNames)
+        {
+            foreach (var dataType in dataTypes)
+            {
+                yield return new object[] { memberName, dataType };
+            }
+        }
     }
 }

--- a/SharpSource/SharpSource/Diagnostics/EnumWithoutDefaultValueAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/EnumWithoutDefaultValueAnalyzer.cs
@@ -46,7 +46,7 @@ public sealed class EnumWithoutDefaultValueAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (!membersOfInterest.Any(m => m is IFieldSymbol f && Convert.ToUInt64(f.ConstantValue) == 0))
+        if (!membersOfInterest.Any(m => m is IFieldSymbol f && Convert.ToDouble(f.ConstantValue) == 0))
         {
             Report(symbol, context);
         }

--- a/SharpSource/SharpSource/Diagnostics/EnumWithoutDefaultValueAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/EnumWithoutDefaultValueAnalyzer.cs
@@ -46,7 +46,7 @@ public sealed class EnumWithoutDefaultValueAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (!membersOfInterest.Any(m => m is IFieldSymbol { ConstantValue: 0 }))
+        if (!membersOfInterest.Any(m => m is IFieldSymbol f && Convert.ToUInt64(f.ConstantValue) == 0))
         {
             Report(symbol, context);
         }


### PR DESCRIPTION
I've added a unit test to demonstrate the issue. The pattern-based check in EnumWithoutDefaultValueAnalyzer.cs:49 only works when the enum is using its default underlying type (int). When it is any other numerical type (byte, short, ushort, uint, long or ulong) it crashes due to an invalid cast.

`Convert.ToULong()` works because it uses the IConvertible interface on the numerical types to convert between values, and using `ToUlong()` instead of f.ex. `ToInt()` means we don't have to check for all possible types, since we are only interested in if the value is 0.