### PR TITLE
Revert back to 4.8.0 for Microsoft.CodeAnalysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 https://keepachangelog.com/en/1.0.0/
 
 ## [1.25.1] - 2024-09-15
-- Reverted an earlier dependency bump which caused the analyzers to become incompatible with Visual Studi
+- Reverted an earlier dependency bump which caused the analyzers to become incompatible with Visual Studio
 
 ## [1.25.0] - 2024-09-15
 - `ConcurrentDictionaryEmptyCheck`: A `ConcurrentDictionary` is checked for emptiness without using `.IsEmpty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.25.1] - 2024-09-15
+- Reverted an earlier dependency bump which caused the analyzers to become incompatible with Visual Studi
+
 ## [1.25.0] - 2024-09-15
 - `ConcurrentDictionaryEmptyCheck`: A `ConcurrentDictionary` is checked for emptiness without using `.IsEmpty`
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.9.3168" />

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.25.0" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.25.1" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.25.0</PackageVersion>
+    <PackageVersion>1.25.1</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>


### PR DESCRIPTION
Without this, the VSIX extension silently fails and the Nuget package shows this warning:

> The analyzer assembly 'C:\Users\jer_v\.nuget\packages\sharpsource\1.25.0\analyzers\dotnet\cs\SharpSource.dll' references version '4.11.0.0' of the compiler, which is newer than the currently running version '4.9.0.0'.	