### PR TITLE
TestMethodWithoutTestAttribute: Don't trigger when NUnit.TestCase` or `NUnit.TestCaseSource` is present on a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 https://keepachangelog.com/en/1.0.0/
 
+## [1.27.1] - 2025-02-22
+- `TestMethodWithoutTestAttribute`: Don't trigger when `NUnit.TestCase` or `NUnit.TestCaseSource` is present on a method
+
 ## [1.27.0] - 2025-01-09
 - `ElementaryMethodsOfTypeInCollectionNotOverridden`: Don't exclude all `System` assembly types, exclude only structs
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,5 +4,6 @@
     <LangVersion>11.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisLevel>latest</AnalysisLevel>
+    <NoWarn>NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or add a reference yourself:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="SharpSource" Version="1.27.0" PrivateAssets="All" />
+    <PackageReference Include="SharpSource" Version="1.27.1" PrivateAssets="All" />
 </ItemGroup>
 ```
 

--- a/SharpSource/SharpSource.Package/SharpSource.Package.csproj
+++ b/SharpSource/SharpSource.Package/SharpSource.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>SharpSource</PackageId>
-    <PackageVersion>1.27.0</PackageVersion>
+    <PackageVersion>1.27.1</PackageVersion>
     <Authors>Jeroen Vannevel</Authors>
     <PackageLicenseUrl>https://github.com/Vannevelj/SharpSource/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vannevelj/SharpSource</PackageProjectUrl>

--- a/SharpSource/SharpSource.Test/TestMethodWithoutTestAttributeTests.cs
+++ b/SharpSource/SharpSource.Test/TestMethodWithoutTestAttributeTests.cs
@@ -304,7 +304,7 @@ class MyClass
     }
 
     [TestMethod]
-    public async Task TestMethodWithoutTestAttribute_OtherAttributeIsTestRelated_TestCase()
+    public async Task TestMethodWithoutTestAttribute_Nunit_TestCase()
     {
         var original = @"
 using System;
@@ -321,11 +321,11 @@ class MyClass
 }
 ";
 
-        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Method MyMethod might be missing a test attribute"));
+        await VerifyCS.VerifyNoDiagnostic(original);
     }
 
     [TestMethod]
-    public async Task TestMethodWithoutTestAttribute_OtherAttributeIsTestRelated_TestCaseSource()
+    public async Task TestMethodWithoutTestAttribute_NUnit_TestCaseSource()
     {
         var original = @"
 using System;
@@ -348,7 +348,27 @@ class MyClass
 }
 ";
 
-        await VerifyCS.VerifyDiagnosticWithoutFix(original, VerifyCS.Diagnostic().WithMessage("Method MyMethod might be missing a test attribute"));
+        await VerifyCS.VerifyNoDiagnostic(original);
+    }
+
+    [TestMethod]
+    public async Task TestMethodWithoutTestAttribute_Nunit_WithoutTestFixture_TestCase()
+    {
+        var original = @"
+using System;
+using NUnit.Framework;
+
+class MyClass
+{
+    [TestCase(3)]
+    public void {|#0:MyMethod|}(int x)
+    {
+
+    }
+}
+";
+
+        await VerifyCS.VerifyNoDiagnostic(original);
     }
 
     [BugVerificationTest(IssueUrl = "https://github.com/Vannevelj/SharpSource/issues/22")]

--- a/SharpSource/SharpSource/Diagnostics/TestMethodWithoutTestAttributeAnalyzer.cs
+++ b/SharpSource/SharpSource/Diagnostics/TestMethodWithoutTestAttributeAnalyzer.cs
@@ -34,7 +34,9 @@ public class TestMethodWithoutTestAttributeAnalyzer : DiagnosticAnalyzer
 
             var testMethodAttributeSymbols = ImmutableArray.Create(
                 compilationContext.Compilation.GetTypeByMetadataName("Xunit.FactAttribute"),
-                compilationContext.Compilation.GetTypeByMetadataName("Xunit.TheoryAttribute")
+                compilationContext.Compilation.GetTypeByMetadataName("Xunit.TheoryAttribute"),
+                compilationContext.Compilation.GetTypeByMetadataName("NUnit.Framework.TestCaseAttribute"),
+                compilationContext.Compilation.GetTypeByMetadataName("NUnit.Framework.TestCaseSourceAttribute")
             );
 
             var taskTypes = ImmutableArray.Create(
@@ -45,9 +47,7 @@ public class TestMethodWithoutTestAttributeAnalyzer : DiagnosticAnalyzer
             var allowedAdditionalAttributes = ImmutableArray.Create(
                 compilationContext.Compilation.GetTypeByMetadataName("Xunit.ClassDataAttribute"),
                 compilationContext.Compilation.GetTypeByMetadataName("Xunit.InlineDataAttribute"),
-                compilationContext.Compilation.GetTypeByMetadataName("Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute"),
-                compilationContext.Compilation.GetTypeByMetadataName("NUnit.Framework.TestCaseAttribute"),
-                compilationContext.Compilation.GetTypeByMetadataName("NUnit.Framework.TestCaseSourceAttribute")
+                compilationContext.Compilation.GetTypeByMetadataName("Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute")
             );
 
             compilationContext.RegisterSymbolAction(context => Analyze(context, testClassAttributeSymbols, testMethodAttributeSymbols, taskTypes, allowedAdditionalAttributes), SymbolKind.Method);


### PR DESCRIPTION
Fixes #360 